### PR TITLE
ویژگی: بازیابی دانلودرهای مانهوا، گالری و Erome

### DIFF
--- a/bot/handlers/downloader.py
+++ b/bot/handlers/downloader.py
@@ -17,137 +17,245 @@ logger = logging.getLogger(__name__)
 router = Router()
 
 URL_REGEX = r'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
-SUPPORTED_VIDEO_DOMAINS = [helpers.PORNHUB_DOMAIN, helpers.EPORNER_DOMAIN] # Add other yt-dlp sites here
 
-# --- FSM States for Download Flow ---
+# --- Site Configuration ---
+SITE_CONFIG = {
+    helpers.TOONILY_COM_DOMAIN: {"get_chapters": helpers.find_all_chapters_com, "needs_selenium": True},
+    helpers.TOONILY_ME_DOMAIN: {"get_chapters": helpers.mn2_get_chapters, "needs_selenium": False},
+    helpers.MANHWACLAN_DOMAIN: {"get_chapters": helpers.mc_get_chapters_and_title, "needs_selenium": False},
+    helpers.MANGA_DISTRICT_DOMAIN: {"get_chapters": helpers.md_get_chapters_and_title, "needs_selenium": False},
+    helpers.COMICK_DOMAIN: {"get_chapters": helpers.cm_get_info_and_chapters, "needs_selenium": True},
+}
+MANHWA_DOMAINS = SITE_CONFIG.keys()
+VIDEO_DOMAINS = [helpers.PORNHUB_DOMAIN, helpers.EPORNER_DOMAIN]
+
+# --- FSM States ---
 class DownloadFSM(StatesGroup):
+    manhwa_selecting_chapters = State()
+    manhwa_awaiting_zip_option = State()
+    gallery_awaiting_zip_option = State()
+    erome_awaiting_choice = State()
     yt_dlp_selecting_quality = State()
 
-# --- Main Link Handler for Download Flow ---
+# --- Main Link Handler ---
 @router.message(UserFlow.downloading, F.text.regexp(URL_REGEX))
-@cooldown(seconds=5)
+@cooldown(seconds=10)
 async def handle_link(message: types.Message, state: FSMContext, session: AsyncSession, bot: Bot):
     url = message.text.strip()
     user_id = message.from_user.id
     domain = urllib.parse.urlparse(url).netloc.lower().replace('www.', '')
 
-    # Check if the domain is a supported video domain
-    if domain not in SUPPORTED_VIDEO_DOMAINS:
-        await message.answer(
-            "این سایت در حال حاضر برای دانلود ویدیو پشتیبانی نمی‌شود. لطفاً یک لینک از سایت‌های پشتیبانی شده ارسال کنید.",
-            reply_markup=get_main_menu_keyboard()
-        )
-        await state.set_state(UserFlow.main_menu)
-        return
+    all_supported_domains = list(MANHWA_DOMAINS) + helpers.GALLERY_DL_SITES + helpers.GALLERY_DL_ZIP_SITES + [helpers.EROME_DOMAIN] + VIDEO_DOMAINS
+    if domain not in all_supported_domains:
+         await message.answer("This site is not currently supported for downloads.")
+         return
 
-    # --- Check Public Archive ---
-    url_hash = PublicArchive.create_hash(url)
-    archived_item = await database.get_public_archive_item(session, url_hash)
-    if archived_item:
-        logger.info(f"URL {url} found in public archive. Forwarding message.")
-        await message.answer("این ویدیو قبلاً دانلود شده است. در حال ارسال برای شما...")
-        try:
-            await bot.copy_message(
-                chat_id=user_id,
-                from_chat_id=archived_item.channel_id,
-                message_id=archived_item.message_id
-            )
-            await message.answer("✅ ویدیو ارسال شد.", reply_markup=get_main_menu_keyboard())
-            await state.set_state(UserFlow.main_menu)
-            return # CRITICAL FIX: Ensure we exit after successful forward.
-        except Exception as e:
-            logger.error(f"Failed to forward message from archive: {e}. Proceeding with re-download.")
-            await message.answer("خطایی در ارسال از آرشیو رخ داد. با این حال، ما دانلود مجدد را برای شما شروع می‌کنیم...")
-
-    # --- Proceed with new download ---
     is_allowed, reason = await helpers.check_subscription(session, user_id, domain)
     if not is_allowed:
         await message.answer(reason)
         return
 
     await database.log_download_activity(session, user_id, domain)
-    await handle_yt_dlp_link(message, state, url)
+
+    # --- Video duplicate check ---
+    if domain in VIDEO_DOMAINS:
+        url_hash = PublicArchive.create_hash(url)
+        archived_item = await database.get_public_archive_item(session, url_hash)
+        if archived_item:
+            logger.info(f"URL {url} found in public archive. Forwarding message.")
+            await message.answer("This video has been downloaded before. Forwarding it to you...")
+            try:
+                await bot.copy_message(chat_id=user_id, from_chat_id=archived_item.channel_id, message_id=archived_item.message_id)
+                return
+            except Exception as e:
+                logger.error(f"Failed to forward message from archive: {e}. Proceeding with re-download.")
+                await message.answer("Failed to forward from archive. Proceeding with a fresh download...")
+
+    # --- Route to the correct handler ---
+    if domain in MANHWA_DOMAINS:
+        await handle_manhwa_link(message, state, url, domain)
+    elif domain in helpers.GALLERY_DL_SITES or domain in helpers.GALLERY_DL_ZIP_SITES:
+        await handle_gallery_dl_link(message, state, url)
+    elif domain == helpers.EROME_DOMAIN:
+        await handle_erome_link(message, state, url)
+    elif domain in VIDEO_DOMAINS:
+        await handle_yt_dlp_link(message, state, url)
+    else:
+        await message.answer("Could not determine the correct downloader for this site.")
 
 
 async def handle_yt_dlp_link(message: types.Message, state: FSMContext, url: str):
-    """
-    Handles video links, extracts quality formats, and presents them to the user.
-    """
-    status_msg = await message.answer("🔎 در حال استخراج اطلاعات ویدیو...")
+    status_msg = await message.answer("🔎 Extracting video information...")
+    info = await asyncio.to_thread(helpers.get_full_video_info, url)
+    if not info:
+        await status_msg.edit_text("❌ Error: Could not extract video information.")
+        return
+    formats = [f for f in info.get('formats', []) if f.get('vcodec') != 'none' and f.get('height')]
+    if not formats:
+        await status_msg.edit_text("No downloadable video qualities found.")
+        return
+    best_formats = {f['height']: f for f in sorted(formats, key=lambda x: x.get('tbr', 0), reverse=True) if f.get('height')}
+    await state.set_state(DownloadFSM.yt_dlp_selecting_quality)
+    await state.update_data(yt_info=info, yt_url=url, user_id=message.from_user.id)
+    keyboard = [[types.InlineKeyboardButton(text=f"{h}p ({(f.get('filesize') or f.get('filesize_approx') or 0) / (1024*1024):.2f} MB)", callback_data=f"yt_{f['format_id']}")] for h, f in sorted(best_formats.items(), reverse=True)]
+    keyboard.append([types.InlineKeyboardButton(text="Best Quality (Auto)", callback_data='yt_best')])
+    await status_msg.edit_text(f"✅ Qualities for '{info.get('title', 'video')}':", reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard))
 
+async def handle_erome_link(message: types.Message, state: FSMContext, url: str):
+    status_msg = await message.answer("🔎 Analyzing Erome album, this may take a moment...")
+    driver = None
     try:
-        info = await asyncio.to_thread(helpers.get_full_video_info, url)
+        driver = await asyncio.to_thread(helpers.setup_chrome_driver)
+        if not driver:
+            raise Exception("Could not start browser driver.")
 
-        if not info:
-            await status_msg.edit_text("❌ خطا: اطلاعات ویدیو قابل استخراج نیست. لینک ممکن است خراب، پشتیبانی نشده یا نیازمند کوکی باشد.")
+        title, media_urls = await asyncio.to_thread(helpers.er_get_album_media_selenium, url, driver)
+
+        if not media_urls or (not media_urls.get('images') and not media_urls.get('videos')):
+            await status_msg.edit_text("No images or videos found in this album.")
             return
 
-        formats = [f for f in info.get('formats', []) if f.get('vcodec') != 'none' and f.get('height')]
-        if not formats:
-            await status_msg.edit_text("هیچ کیفیت قابل دانلودی برای این ویدیو یافت نشد.")
-            return
-
-        best_formats = {}
-        for f in formats:
-            h = f.get('height')
-            if h:
-                current_tbr = f.get('tbr') or 0
-                if h not in best_formats or current_tbr > (best_formats[h].get('tbr') or 0):
-                    best_formats[h] = f
-
-        await state.set_state(DownloadFSM.yt_dlp_selecting_quality)
+        await state.set_state(DownloadFSM.erome_awaiting_choice)
         await state.update_data(
-            yt_info=info,
-            yt_url=url,
+            er_title=title,
+            er_media=media_urls,
             user_id=message.from_user.id
         )
 
+        num_images = len(media_urls.get('images', []))
+        num_videos = len(media_urls.get('videos', []))
+
         keyboard_buttons = []
-        for h, f in sorted(best_formats.items(), reverse=True):
-            size_mb = (f.get('filesize') or f.get('filesize_approx') or 0) / (1024*1024)
-            keyboard_buttons.append([
-                types.InlineKeyboardButton(
-                    text=f"{h}p ({size_mb:.2f} MB)",
-                    callback_data=f"yt_{f['format_id']}"
-                )
-            ])
-        keyboard_buttons.append([types.InlineKeyboardButton(text="بهترین کیفیت (خودکار)", callback_data='yt_best')])
+        if num_images > 0:
+            keyboard_buttons.append([types.InlineKeyboardButton(text=f"🖼️ Download {num_images} Images", callback_data="er_choice_images")])
+        if num_videos > 0:
+             keyboard_buttons.append([types.InlineKeyboardButton(text=f"🎬 Download {num_videos} Videos", callback_data="er_choice_videos")])
+        if num_images > 0 and num_videos > 0:
+            keyboard_buttons.append([types.InlineKeyboardButton(text="📥 Download Both", callback_data="er_choice_both")])
 
         await status_msg.edit_text(
-            f"✅ کیفیت‌های موجود برای '{info.get('title', 'video')}':",
+            f"✅ Album '{title}' analyzed. What would you like to download?",
             reply_markup=types.InlineKeyboardMarkup(inline_keyboard=keyboard_buttons)
         )
-    except Exception as e:
-        logger.error(f"Error in handle_yt_dlp_link: {e}", exc_info=True)
-        await status_msg.edit_text(f"❌ خطای ناشناخته‌ای در پردازش لینک شما رخ داد: {e}")
-        await state.set_state(UserFlow.main_menu)
 
+    except Exception as e:
+        logger.error(f"Error handling Erome link {url}: {e}", exc_info=True)
+        await status_msg.edit_text(f"An error occurred: {str(e)}")
+    finally:
+        if driver:
+            driver.quit()
+
+async def handle_gallery_dl_link(message: types.Message, state: FSMContext, url: str):
+    user_id = message.from_user.id
+    await state.set_state(DownloadFSM.gallery_awaiting_zip_option)
+    await state.update_data(gdl_url=url, user_id=user_id)
+    keyboard = types.InlineKeyboardMarkup(inline_keyboard=[[types.InlineKeyboardButton(text="Yes, create ZIP", callback_data="gdl_zip_yes")], [types.InlineKeyboardButton(text="No, send individually", callback_data="gdl_zip_no")]])
+    await message.answer("This looks like a gallery. Compress to a single ZIP?", reply_markup=keyboard)
+
+async def handle_manhwa_link(message: types.Message, state: FSMContext, url: str, domain: str):
+    config = SITE_CONFIG[domain]
+    status_msg = await message.answer(f"🔎 Analyzing link from {domain}...")
+    driver = None
+    try:
+        if config["needs_selenium"]:
+            driver = await asyncio.to_thread(helpers.setup_chrome_driver)
+        get_chapters_func = config["get_chapters"]
+        chapters, title = await asyncio.to_thread(get_chapters_func, url, driver) if driver else await asyncio.to_thread(get_chapters_func, url)
+        if not chapters:
+            await status_msg.edit_text("No chapters found.")
+            return
+        await state.set_state(DownloadFSM.manhwa_selecting_chapters)
+        await state.update_data(chapters=chapters, title=title, prefix=domain, selected_indices=[], current_page=0)
+        keyboard = helpers.create_chapter_keyboard(chapters, [], 0, domain)
+        await status_msg.edit_text(f"✅ Found {len(chapters)} chapters for '{title}'. Select chapters:", reply_markup=keyboard)
+    except Exception as e:
+        logger.error(f"Error handling manhwa link {url}: {e}", exc_info=True)
+        await status_msg.edit_text(f"An error occurred: {e}")
+    finally:
+        if driver: driver.quit()
+
+# --- FSM Callback Handlers ---
 
 @router.callback_query(DownloadFSM.yt_dlp_selecting_quality, F.data.startswith("yt_"))
 async def handle_yt_dlp_quality_choice(query: types.CallbackQuery, state: FSMContext):
-    """Processes the user's quality selection and starts the download task."""
     await query.answer()
     selected_format = query.data.split('_', 1)[1]
     data = await state.get_data()
+    await query.message.edit_text(f"✅ Request for '{data.get('yt_info', {}).get('title', 'video')}' added to queue.")
+    download_tasks.download_video_task.delay(chat_id=query.message.chat.id, url=data['yt_url'], selected_format=selected_format, video_info_json=json.dumps(data['yt_info']), user_id=data['user_id'])
+    await state.clear()
 
-    info = data.get('yt_info')
-    url = data.get('yt_url')
+
+@router.callback_query(DownloadFSM.erome_awaiting_choice, F.data.startswith("er_choice_"))
+async def handle_erome_choice(query: types.CallbackQuery, state: FSMContext):
+    await query.answer()
+    choice = query.data.replace("er_choice_", "")
+    data = await state.get_data()
+
+    title = data.get('er_title')
+    media = data.get('er_media')
     user_id = data.get('user_id')
 
-    if not all([info, url, user_id]):
-        await query.message.edit_text("خطا: اطلاعات دانلود منقضی شده است. لطفاً دوباره لینک را ارسال کنید.", reply_markup=get_main_menu_keyboard())
-        await state.set_state(UserFlow.main_menu)
+    if not all([title, media, user_id]):
+        await query.message.edit_text("Error: Download information has expired. Please send the link again.")
+        await state.clear()
         return
 
-    await query.message.edit_text(f"✅ درخواست شما برای '{info.get('title', 'video')}' به صف دانلود اضافه شد.")
+    await query.message.edit_text(f"✅ Your request for '{title}' has been added to the queue.")
 
-    # This is the new, simplified download task
-    download_tasks.download_video_task.delay(
+    download_tasks.process_erome_album_task.delay(
         chat_id=query.message.chat.id,
-        url=url,
-        selected_format=selected_format,
-        video_info_json=json.dumps(info),
-        user_id=user_id
+        user_id=user_id,
+        album_title=title,
+        media_urls=media,
+        choice=choice
     )
-    # Return user to the main menu after starting the download
-    await state.set_state(UserFlow.main_menu)
+    await state.clear()
+
+
+@router.callback_query(DownloadFSM.gallery_awaiting_zip_option, F.data.startswith("gdl_zip_"))
+async def handle_gallery_dl_zip_choice(query: types.CallbackQuery, state: FSMContext):
+    await query.answer()
+    create_zip = query.data == "gdl_zip_yes"
+    data = await state.get_data()
+    await query.message.edit_text(f"✅ Request for '{urllib.parse.urlparse(data['gdl_url']).netloc}' added to queue.")
+    download_tasks.process_gallery_dl_task.delay(query.message.chat.id, data['gdl_url'], create_zip=create_zip, user_id=data['user_id'])
+    await state.clear()
+
+@router.callback_query(DownloadFSM.manhwa_selecting_chapters)
+async def handle_manhwa_chapter_selection(query: types.CallbackQuery, state: FSMContext):
+    await query.answer()
+    data = await state.get_data()
+    prefix = data['prefix']
+    action = query.data[len(prefix) + 1:]
+    if action.startswith("toggle_"):
+        index = int(action.split('_')[-1])
+        if index in data['selected_indices']: data['selected_indices'].remove(index)
+        else: data['selected_indices'].append(index)
+    elif action.startswith("page_"):
+        data['current_page'] = int(action.split('_')[-1])
+    elif action == "select_all":
+        data['selected_indices'] = list(range(len(data['chapters'])))
+    elif action == "deselect_all":
+        data['selected_indices'] = []
+    elif action == "start_download":
+        if not data['selected_indices']:
+            await query.answer("Please select at least one chapter.", show_alert=True)
+            return
+        await state.set_state(DownloadFSM.manhwa_awaiting_zip_option)
+        keyboard = types.InlineKeyboardMarkup(inline_keyboard=[[types.InlineKeyboardButton(text="Yes, create ZIP", callback_data="manhwa_zip_yes")], [types.InlineKeyboardButton(text="No, send as files", callback_data="manhwa_zip_no")]])
+        await query.message.edit_text("Compress downloads into ZIP files?", reply_markup=keyboard)
+        return
+    await state.update_data(current_page=data['current_page'], selected_indices=data['selected_indices'])
+    keyboard = helpers.create_chapter_keyboard(data['chapters'], data['selected_indices'], data['current_page'], prefix)
+    await query.message.edit_reply_markup(reply_markup=keyboard)
+
+@router.callback_query(DownloadFSM.manhwa_awaiting_zip_option, F.data.startswith("manhwa_zip_"))
+async def handle_manhwa_zip_choice(query: types.CallbackQuery, state: FSMContext):
+    await query.answer()
+    create_zip = query.data == "manhwa_zip_yes"
+    data = await state.get_data()
+    chapters_to_download = [data['chapters'][i] for i in sorted(data['selected_indices'])]
+    await query.message.edit_text(f"✅ Request for {len(chapters_to_download)} chapters of '{data['title']}' sent to queue.")
+    download_tasks.process_manhwa_task.delay(chat_id=query.message.chat.id, manhwa_title=data['title'], chapters_to_download=chapters_to_download, create_zip=create_zip, site_key=data['prefix'])
+    await state.clear()

--- a/tasks/download_tasks.py
+++ b/tasks/download_tasks.py
@@ -2,15 +2,21 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import tempfile
+import urllib.parse
+from pathlib import Path
+import concurrent.futures
 
+from aiogram import Bot
 from aiogram.types import FSInputFile
+
 from config import settings
 from utils import database, helpers, telegram_api, video_processor
 from utils.db_session import AsyncSessionLocal
-from utils.models import PublicArchive
 from tasks.celery_app import celery_app
 from bot.handlers.common import get_main_menu_keyboard
+from utils.models import PublicArchive
 
 logger = logging.getLogger(__name__)
 
@@ -30,90 +36,153 @@ def download_video_task(chat_id: int, url: str, selected_format: str, video_info
 
     async def _async_worker():
         bot_instance = get_bot_instance()
-        status_message = await bot_instance.send_message(chat_id=chat_id, text="📥 دانلود ویدیوی شما در حال شروع است...")
+        status_message = await bot_instance.send_message(chat_id=chat_id, text="📥 Your video download is starting...")
 
-        # Ensure video_info is populated if it's empty
         if not video_info:
-            try:
-                info = await asyncio.to_thread(helpers.get_full_video_info, url)
-                if not info:
-                    await bot_instance.edit_message_text(text="❌ امکان دریافت متادیتای ویدیو وجود نداشت.", chat_id=chat_id, message_id=status_message.message_id)
-                    return
-                video_info.update(info)
-            except Exception as e:
-                logger.error(f"Failed to get video info for {url}: {e}")
-                await bot_instance.edit_message_text(text=f"❌ خطا در دریافت اطلاعات ویدیو: {e}", chat_id=chat_id, message_id=status_message.message_id)
+            info = await asyncio.to_thread(helpers.get_full_video_info, url)
+            if not info:
+                await bot_instance.edit_message_text(text="❌ Could not fetch video metadata.", chat_id=chat_id, message_id=status_message.message_id)
                 return
+            video_info.update(info)
 
         title = helpers.sanitize_filename(video_info.get('title', 'untitled_video'))
 
         with tempfile.TemporaryDirectory() as temp_dir:
             try:
-                await bot_instance.edit_message_text(text=f"📥 در حال دانلود: {title}...", chat_id=chat_id, message_id=status_message.message_id)
-
+                await bot_instance.edit_message_text(text=f"📥 Downloading: {title}...", chat_id=chat_id, message_id=status_message.message_id)
                 raw_video_path = await asyncio.to_thread(helpers.download_video, url, temp_dir, selected_format)
-                if not raw_video_path: raise Exception("دانلود ویدیو ناموفق بود.")
-
-                # Video repair is often necessary
+                if not raw_video_path: raise Exception("Video download failed.")
                 repaired_path = os.path.join(temp_dir, "repaired.mp4")
                 if not await asyncio.to_thread(video_processor.repair_video, raw_video_path, repaired_path):
-                     repaired_path = raw_video_path # Fallback to original if repair fails
-
+                     repaired_path = raw_video_path
                 duration, width, height = await asyncio.to_thread(video_processor.get_video_metadata, repaired_path)
-
-                # Generate a thumbnail from the video itself
                 generated_thumb_path = os.path.join(temp_dir, "generated_thumb.jpg")
-                thumb_success = await asyncio.to_thread(
-                    video_processor.generate_thumbnail_from_video, repaired_path, generated_thumb_path
-                )
+                thumb_success = await asyncio.to_thread(video_processor.generate_thumbnail_from_video, repaired_path, generated_thumb_path)
                 final_thumb_path = generated_thumb_path if thumb_success else None
-
-                # --- Upload to Public Archive ---
-                await bot_instance.edit_message_text(text="📤 در حال آپلود در آرشیو عمومی...", chat_id=chat_id, message_id=status_message.message_id)
+                await bot_instance.edit_message_text(text="📤 Uploading to public archive...", chat_id=chat_id, message_id=status_message.message_id)
                 public_channel_id = settings.public_archive_channel_id
-
-                public_message_id = await telegram_api.upload_video(
-                    bot=bot_instance,
-                    target_chat_id=public_channel_id,
-                    file_path=repaired_path,
-                    thumb_path=final_thumb_path,
-                    caption=title,
-                    duration=duration,
-                    width=width,
-                    height=height
-                )
-                if not public_message_id:
-                    raise Exception("آپلود در آرشیو عمومی ناموفق بود.")
-
-                # --- Save to Database ---
+                public_message_id = await telegram_api.upload_video(bot=bot_instance, target_chat_id=public_channel_id, file_path=repaired_path, thumb_path=final_thumb_path, caption=title, duration=duration, width=width, height=height)
+                if not public_message_id: raise Exception("Upload to public archive failed.")
                 async with AsyncSessionLocal() as session:
-                    await database.add_public_archive_item(
-                        session=session,
-                        url=url,
-                        message_id=public_message_id,
-                        channel_id=public_channel_id
-                    )
-
-                # --- Send to User ---
-                await bot_instance.edit_message_text(text="📨 در حال ارسال برای شما...", chat_id=chat_id, message_id=status_message.message_id)
-                await bot_instance.copy_message(
-                    chat_id=chat_id,
-                    from_chat_id=public_channel_id,
-                    message_id=public_message_id
-                )
-
+                    await database.add_public_archive_item(session=session, url=url, message_id=public_message_id, channel_id=public_channel_id)
+                await bot_instance.edit_message_text(text="📨 Sending to you...", chat_id=chat_id, message_id=status_message.message_id)
+                await bot_instance.copy_message(chat_id=chat_id, from_chat_id=public_channel_id, message_id=public_message_id)
                 await bot_instance.delete_message(chat_id=chat_id, message_id=status_message.message_id)
-                await bot_instance.send_message(chat_id=chat_id, text="✅ دانلود شما با موفقیت انجام شد.", reply_markup=get_main_menu_keyboard())
-
+                await bot_instance.send_message(chat_id=chat_id, text="✅ Download complete.", reply_markup=get_main_menu_keyboard())
             except Exception as e:
                 logger.error(f"Celery Video Task Error: {e}", exc_info=True)
-                await bot_instance.edit_message_text(
-                    text=f"❌ خطایی در حین پردازش ویدیو رخ داد: {e}",
-                    chat_id=chat_id,
-                    message_id=status_message.message_id
-                )
-                await bot_instance.send_message(
-                    chat_id=chat_id, text="لطفاً دوباره امتحان کنید یا با ادمین تماس بگیرید.", reply_markup=get_main_menu_keyboard()
-                )
+                await bot_instance.edit_message_text(text=f"❌ An error occurred during video processing: {e}", chat_id=chat_id, message_id=status_message.message_id)
+                await bot_instance.send_message(chat_id=chat_id, text="Please try again or contact an admin.", reply_markup=get_main_menu_keyboard())
+    helpers.run_async_in_sync(_async_worker())
 
+@celery_app.task(name="tasks.process_erome_album_task")
+def process_erome_album_task(chat_id: int, user_id: int, album_title: str, media_urls: dict, choice: str):
+    async def _async_worker():
+        bot = get_bot_instance()
+        images_to_dl = media_urls.get('images', []) if choice in ['images', 'both'] else []
+        videos_to_dl = media_urls.get('videos', []) if choice in ['videos', 'both'] else []
+        with tempfile.TemporaryDirectory() as temp_dir:
+            if images_to_dl:
+                status_msg = await bot.send_message(chat_id=chat_id, text=f"📥 Downloading {len(images_to_dl)} images for '{album_title}'...")
+                for i, img_url in enumerate(images_to_dl):
+                    filename = os.path.basename(urllib.parse.urlparse(img_url).path) or f"erome_img_{i}.jpg"
+                    await bot.edit_message_text(text=f"[{i+1}/{len(images_to_dl)}] 🖼️ Downloading {filename}...", chat_id=chat_id, message_id=status_msg.message_id)
+                    try:
+                        response = requests.get(img_url, headers=helpers.EROME_HEADERS, stream=True, timeout=60)
+                        response.raise_for_status()
+                        img_path = os.path.join(temp_dir, filename)
+                        with open(img_path, 'wb') as f: shutil.copyfileobj(response.raw, f)
+                        await bot.send_photo(chat_id=chat_id, photo=FSInputFile(img_path), caption=filename)
+                    except Exception as e:
+                        logger.error(f"Failed to download Erome image {img_url}: {e}")
+                        await bot.send_message(chat_id=chat_id, text=f"❌ Failed to process image: {filename}")
+                await bot.delete_message(chat_id=chat_id, message_id=status_msg.message_id)
+            if videos_to_dl:
+                for vid_url in videos_to_dl:
+                    download_video_task.delay(chat_id=chat_id, url=vid_url, selected_format='best', video_info_json='{}', user_id=user_id)
+    helpers.run_async_in_sync(_async_worker())
+
+@celery_app.task(name="tasks.process_gallery_dl_task")
+def process_gallery_dl_task(chat_id: int, url: str, create_zip: bool, user_id: int):
+    async def _async_worker():
+        bot = get_bot_instance()
+        status_message = await bot.send_message(chat_id=chat_id, text=f"📥 Request for '{urllib.parse.urlparse(url).netloc}' received...")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            zip_path = None
+            try:
+                downloaded_files, error = await helpers.run_gallery_dl_download(url, temp_dir)
+                if error or not downloaded_files: raise Exception(error or "No files were downloaded.")
+                if create_zip:
+                    await bot.edit_message_text(text="🗜️ Creating ZIP file...", chat_id=chat_id, message_id=status_message.message_id)
+                    zip_name = f"{helpers.sanitize_filename(urllib.parse.urlparse(url).netloc)}_gallery.zip"
+                    zip_path = os.path.join(os.path.dirname(temp_dir), zip_name)
+                    await asyncio.to_thread(helpers.create_zip_from_folder, temp_dir, zip_path)
+                    await bot.edit_message_text(text=f"📤 Uploading ZIP: {zip_name}", chat_id=chat_id, message_id=status_message.message_id)
+                    await bot.send_document(chat_id=chat_id, document=FSInputFile(zip_path), caption=zip_name)
+                else:
+                    total = len(downloaded_files)
+                    for i, file_path in enumerate(downloaded_files):
+                        filename = os.path.basename(file_path)
+                        await bot.edit_message_text(text=f"📤 Processing {i+1}/{total}: {filename}", chat_id=chat_id, message_id=status_message.message_id)
+                        ext = os.path.splitext(filename)[1].lower()
+                        if ext in ['.jpg', '.jpeg', '.png', '.webp', '.gif']:
+                            await bot.send_photo(chat_id=chat_id, photo=FSInputFile(file_path), caption=filename)
+                        elif ext in ['.mp4', '.mkv', '.webm', '.mov']:
+                            # Videos from galleries are sent through the standard video download task
+                            download_video_task.delay(chat_id=chat_id, url=f"file://{file_path}", selected_format='best', video_info_json='{}', user_id=user_id)
+                        else:
+                            await bot.send_document(chat_id=chat_id, document=FSInputFile(file_path), caption=filename)
+                await bot.edit_message_text(text="✅ All files sent successfully.", chat_id=chat_id, message_id=status_message.message_id)
+            except Exception as e:
+                logger.error(f"Celery Gallery-DL Task Error: {e}", exc_info=True)
+                await bot.edit_message_text(text=f"❌ An error occurred: {e}", chat_id=chat_id, message_id=status_message.message_id)
+            finally:
+                if zip_path and os.path.exists(zip_path): os.remove(zip_path)
+    helpers.run_async_in_sync(_async_worker())
+
+@celery_app.task(name="tasks.process_manhwa_task")
+def process_manhwa_task(chat_id: int, manhwa_title: str, chapters_to_download: list, create_zip: bool, site_key: str):
+    site_configs = {'toonily.com': {'get_images': helpers.get_chapter_image_urls_com, 'needs_selenium': True}, 'toonily.me': {'get_images': helpers.mn2_get_chapter_images, 'needs_selenium': False}, 'manhwaclan.com': {'get_images': helpers.mc_get_chapter_image_urls, 'needs_selenium': False}, 'mangadistrict.com': {'get_images': helpers.md_get_chapter_image_urls, 'needs_selenium': False}, 'comick.io': {'get_images': helpers.cm_get_chapter_image_urls, 'needs_selenium': False}}
+    config = site_configs.get(site_key)
+    async def _async_worker():
+        bot = get_bot_instance()
+        if not config:
+            await bot.send_message(chat_id=chat_id, text=f"Internal error: No config for {site_key}.")
+            return
+        status_message = await bot.send_message(chat_id=chat_id, text=f"📥 Request for '{manhwa_title}' processing...")
+        driver = None
+        with tempfile.TemporaryDirectory() as base_temp_dir:
+            try:
+                if config['needs_selenium']:
+                    driver = await asyncio.to_thread(helpers.setup_chrome_driver)
+                total_chapters = len(chapters_to_download)
+                for i, chapter in enumerate(chapters_to_download):
+                    await bot.edit_message_text(text=f"[{i+1}/{total_chapters}] 📥 Downloading: {chapter['name']}...", chat_id=chat_id, message_id=status_message.message_id)
+                    chapter_temp_folder = Path(base_temp_dir) / helpers.sanitize_filename(chapter['name'])
+                    chapter_temp_folder.mkdir()
+                    chapter_identifier = chapter.get('hid') if site_key == 'comick.io' else chapter['url']
+                    image_urls = await asyncio.to_thread(config['get_images'], chapter_identifier, driver) if driver else await asyncio.to_thread(config['get_images'], chapter_identifier)
+                    if not image_urls:
+                        await bot.send_message(chat_id=chat_id, text=f"⚠️ No images found for chapter: {chapter['name']}")
+                        continue
+                    headers = {'Referer': f'https://{site_key}/'}
+                    dl_tasks = [(url, os.path.join(chapter_temp_folder, f"{j+1:03d}.jpg"), headers) for j, url in enumerate(image_urls)]
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+                        list(executor.map(helpers.download_single_image, dl_tasks))
+                    if not os.listdir(chapter_temp_folder):
+                        await bot.send_message(chat_id=chat_id, text=f"❌ Download failed for chapter: {chapter['name']}")
+                        continue
+                    if create_zip:
+                        zip_path = Path(base_temp_dir) / f"{helpers.sanitize_filename(chapter['name'])}.zip"
+                        await asyncio.to_thread(helpers.create_zip_from_folder, str(chapter_temp_folder), str(zip_path))
+                        await bot.send_document(chat_id=chat_id, document=FSInputFile(zip_path), caption=zip_path.name)
+                    else:
+                        for img_file in sorted(os.listdir(chapter_temp_folder)):
+                            await bot.send_photo(chat_id=chat_id, photo=FSInputFile(chapter_temp_folder / img_file), caption=img_file)
+                await bot.edit_message_text(text=f"✅ All downloads for '{manhwa_title}' are complete.", chat_id=chat_id, message_id=status_message.message_id)
+            except Exception as e:
+                logger.error(f"Celery Manhwa Task Error for {site_key}: {e}", exc_info=True)
+                await bot.edit_message_text(text=f"❌ An error occurred during download: {e}", chat_id=chat_id, message_id=status_message.message_id)
+            finally:
+                if driver: driver.quit()
     helpers.run_async_in_sync(_async_worker())


### PR DESCRIPTION
این کامیت قابلیت‌های دانلود از سایت‌های مانهوا، گالری و Erome را که در بازسازی اولیه حذف شده بودند، دوباره به ربات اضافه می‌کند.

تغییرات:
- در `bot/handlers/downloader.py`، منطق شناسایی و مدیریت لینک‌های مختلف بازیابی شد.
- کنترل‌کننده‌های FSM برای انتخاب چپتر مانهوا، گزینه‌های ZIP گالری و انتخاب رسانه Erome دوباره فعال شدند.
- در `tasks/download_tasks.py`، وظایف Celery مربوط به `process_manhwa_task`, `process_gallery_dl_task` و `process_erome_album_task` بازیابی شدند.
- تمام این دانلودرها اکنون در جریان "دانلود" که پس از دستور /start قابل دسترسی است، ادغام شده‌اند.