### PR TITLE
رفع اشکال: بازگرداندن منطق کپی فایل و جایگزینی آرشیو شخصی

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
 
     public_archive_channel_id: int
     private_archive_channel_id: int
+    personal_archive_channel_id: int # For customized videos
 
     # --- Optional: For Local Bot API Server ---
     # Set to True if you are running your own Bot API server.

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -181,6 +181,29 @@ async def run_gallery_dl_download(url: str, temp_dir: str) -> Tuple[List[str] | 
         return None, error_message
     return [os.path.join(root, file) for root, _, files in os.walk(temp_dir) for file in files], None
 
+async def download_or_copy_file(bot, file: "File", destination: Path):
+    """
+    Downloads a file using the standard method or copies it directly if a local
+    Bot API server data directory is configured.
+    """
+    from config import settings
+
+    if settings.local_bot_api_enabled and settings.local_bot_api_server_data_dir:
+        source_path = Path(file.file_path)
+        # If the provided path is not absolute, join it with the base data directory
+        if not source_path.is_absolute():
+            source_path = Path(settings.local_bot_api_server_data_dir) / source_path
+
+        logger.info(f"Local Bot API enabled. Attempting to copy from {source_path}")
+        if source_path.exists():
+            shutil.copy(source_path, destination)
+            return
+
+        raise FileNotFoundError(f"Source file not found at {source_path}. Check your local_bot_api_server_data_dir and file path.")
+    else:
+        logger.info(f"Default Telegram API. Downloading file to {destination}")
+        await bot.download_file(file.file_path, destination=str(destination))
+
 def download_single_image(args: Tuple[str, str, dict]) -> bool:
     img_url, file_path, headers = args
     try:


### PR DESCRIPTION
این کامیت مشکل رگرسیون مربوط به دانلود از سرور محلی Bot API را برطرف کرده و سیستم آرشیو شخصی مبتنی بر Telethon را با یک راه حل مبتنی بر پیکربندی جایگزین می‌کند.

تغییرات:
- **اصلاح کپی فایل:** یک تابع کمکی متمرکز `download_or_copy_file` در `utils/helpers.py` ایجاد شد که به طور هوشمند فایل‌ها را از سرور محلی API کپی یا از سرور عمومی دانلود می‌کند. این تابع در تمام وظایف مربوطه استفاده می‌شود.
- **جایگزینی آرشیو شخصی:** قابلیت ایجاد کانال پویا با Telethon حذف شد. به جای آن، یک متغیر `PERSONAL_ARCHIVE_CHANNEL_ID` به `config.py` اضافه شد تا ویدیوهای انکد شده به یک کانال ثابت ارسال شوند.
- **پاکسازی:** تمام کدهای باقی‌مانده و غیرضروری مربوط به Telethon حذف شدند.