### PR TITLE
Fix KeyError: 'video_file_id' in video encoding flow.

### DIFF
--- a/bot/handlers/video.py
+++ b/bot/handlers/video.py
@@ -60,6 +60,7 @@ async def handle_encode_video_entry(message: types.Message, state: FSMContext):
         "file_size": message.video.file_size,
         "options": {"rename": False, "thumb": False, "water": False}
     }
+    await state.update_data(initial_data)
     panel_text, keyboard = await get_encode_panel(state)
     await message.answer(panel_text, reply_markup=keyboard)
 


### PR DESCRIPTION
The `handle_encode_video_entry` function was not saving the initial video data to the FSM state. This caused a `KeyError` when the `handle_start_button` function tried to access `video_file_id` from the state.

This commit adds `await state.update_data(initial_data)` to correctly store the video information, resolving the error.