### PR TITLE
Fix file download with local Bot API server.

### DIFF
--- a/utils/bot_instance.py
+++ b/utils/bot_instance.py
@@ -5,7 +5,9 @@ from aiogram.client.default import DefaultBotProperties
 from config import settings 
 
 # آدرس سرور محلی را مشخص کنید
-LOCAL_API_SERVER = TelegramAPIServer.from_base('http://91.107.146.233:8081')
+LOCAL_API_SERVER = TelegramAPIServer.from_base(
+    'http://91.107.146.233:8081', is_local=True
+)
 
 # یک session با timeout بسیار بالا (مثلاً ۳۰ دقیقه) بسازید
 session = AiohttpSession(


### PR DESCRIPTION
When using a local Bot API server, aiogram needs to be explicitly told that it is running in a local environment. Without this, it generates incorrect file download URLs, leading to '404 Not Found' errors.

This commit configures the TelegramAPIServer instance with `is_local=True` to ensure that file paths are handled correctly for local API servers.