### PR TITLE
Send separate 'task done' message after video encoding.

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -22,6 +22,13 @@ def get_main_menu_keyboard():
         [InlineKeyboardButton(text="🎬 انکد", callback_data="start_encode")]
     ])
 
+def get_task_done_keyboard():
+    """Returns the keyboard for the task done message."""
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="📥 دانلود", callback_data="start_download")],
+        [InlineKeyboardButton(text="🎬 انکد", callback_data="start_encode")]
+    ])
+
 @router.message(CommandStart())
 async def handle_start(message: types.Message, state: FSMContext, session: AsyncSession):
     """

--- a/tasks/video_tasks.py
+++ b/tasks/video_tasks.py
@@ -9,7 +9,7 @@ from config import settings
 from utils import database, helpers, video_processor, telegram_api
 from utils.db_session import AsyncSessionLocal
 from tasks.celery_app import celery_app
-from bot.handlers.common import get_main_menu_keyboard
+from bot.handlers.common import get_task_done_keyboard
 from aiogram.types import File
 
 logger = logging.getLogger(__name__)
@@ -74,9 +74,12 @@ def encode_video_task(user_id: int, username: str, chat_id: int, video_file_id: 
                 chat_id=chat_id,
                 video=FSInputFile(str(final_video_path)),
                 thumbnail=FSInputFile(str(custom_thumb_path)) if custom_thumb_path and custom_thumb_path.exists() else None,
-                caption=f"✅ ویدیوی انکد شده شما: {final_filename}",
-                duration=duration, width=width, height=height,
-                reply_markup=get_main_menu_keyboard()
+                duration=duration, width=width, height=height
+            )
+            await bot_instance.send_message(
+                chat_id=chat_id,
+                text="تسک شما انجام شد✅",
+                reply_markup=get_task_done_keyboard()
             )
 
             private_archive_caption = f"the user: @{username} | {user_id}\n" f"the task: {'/'.join(applied_tasks) or 'none'}"


### PR DESCRIPTION
Previously, a confirmation message was added as a caption to the encoded video. This commit changes the behavior to send the video without a caption, followed by a separate message with the text 'تسک شما انجام شد✅' and a keyboard with 'دانلود' and 'انکد' buttons.

A dedicated keyboard function `get_task_done_keyboard` has been added to `bot/handlers/common.py` to support this change.