### PR TITLE
Restore the persistent 'Help' button.

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -2,7 +2,10 @@ from aiogram import Router, types, F
 from aiogram.filters import Command, CommandStart
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton, ReplyKeyboardRemove
+from aiogram.types import (
+    InlineKeyboardMarkup, InlineKeyboardButton,
+    ReplyKeyboardMarkup, KeyboardButton, ReplyKeyboardRemove
+)
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from utils import database
@@ -22,6 +25,13 @@ def get_main_menu_keyboard():
         [InlineKeyboardButton(text="🎬 انکد", callback_data="start_encode")]
     ])
 
+def get_main_reply_keyboard():
+    """Returns the main persistent reply keyboard."""
+    return ReplyKeyboardMarkup(
+        keyboard=[[KeyboardButton(text="راهنما 📚")]],
+        resize_keyboard=True
+    )
+
 def get_task_done_keyboard():
     """Returns the keyboard for the task done message."""
     return InlineKeyboardMarkup(inline_keyboard=[
@@ -38,12 +48,11 @@ async def handle_start(message: types.Message, state: FSMContext, session: Async
     await database.get_or_create_user(session, user_id=user.id, username=user.username)
     await state.set_state(UserFlow.main_menu)
 
-    start_message = (
-        " خوش آمدید!\n\n"
-        "لطفا یکی از گزینه های زیر را انتخاب کنید:"
-    )
+    start_message = "خوش آمدید!"
+    await message.answer(start_message, reply_markup=get_main_reply_keyboard())
 
-    await message.answer(start_message, reply_markup=get_main_menu_keyboard())
+    menu_message = "لطفا یکی از گزینه های زیر را انتخاب کنید:"
+    await message.answer(menu_message, reply_markup=get_main_menu_keyboard())
 
 @router.callback_query(F.data == "start_download")
 async def start_download_flow(query: types.CallbackQuery, state: FSMContext):
@@ -67,6 +76,7 @@ async def start_encode_flow(query: types.CallbackQuery, state: FSMContext):
     await query.answer()
 
 
+@router.message(F.text == "راهنما 📚")
 @router.message(Command("help"))
 async def handle_help(message: types.Message, session: AsyncSession):
     """


### PR DESCRIPTION
The 'Help' (راهنما) button, which was previously a persistent button at the bottom of the screen, had been removed. This commit restores the button and its functionality.

- A `ReplyKeyboardMarkup` with the 'Help' button is now created in `bot/handlers/common.py`.
- The `/start` command handler now sends this keyboard to the user.
- A message handler has been added to respond to the 'Help' button's text, displaying the help message from the database.