### PR TITLE
Fix TypeError when sorting yt-dlp video formats.

### DIFF
--- a/bot/handlers/downloader.py
+++ b/bot/handlers/downloader.py
@@ -94,7 +94,7 @@ async def handle_yt_dlp_link(message: types.Message, state: FSMContext, url: str
     if not formats:
         await status_msg.edit_text("No downloadable video qualities found.")
         return
-    best_formats = {f['height']: f for f in sorted(formats, key=lambda x: x.get('tbr', 0), reverse=True) if f.get('height')}
+    best_formats = {f['height']: f for f in sorted(formats, key=lambda x: x.get('tbr') or 0, reverse=True) if f.get('height')}
     await state.set_state(DownloadFSM.yt_dlp_selecting_quality)
     await state.update_data(yt_info=info, yt_url=url, user_id=message.from_user.id)
     keyboard = [[types.InlineKeyboardButton(text=f"{h}p ({(f.get('filesize') or f.get('filesize_approx') or 0) / (1024*1024):.2f} MB)", callback_data=f"yt_{f['format_id']}")] for h, f in sorted(best_formats.items(), reverse=True)]


### PR DESCRIPTION
When extracting video formats using yt-dlp, some formats may have a bitrate ('tbr') value of `None`. The previous sorting logic did not handle this case, causing a `TypeError: '<' not supported between instances of 'NoneType' and 'float'`.

This commit modifies the sorting key to treat `None` bitrates as 0, preventing the error and ensuring that formats can always be sorted correctly.