### PR TITLE
Fix three separate bugs affecting gallery-dl downloads.

### DIFF
--- a/tasks/download_tasks.py
+++ b/tasks/download_tasks.py
@@ -150,7 +150,7 @@ def process_gallery_dl_task(chat_id: int, url: str, create_zip: bool, user_id: i
                         else:
                             await bot.send_document(chat_id=chat_id, document=FSInputFile(file_path), caption=filename)
                     await bot.delete_message(chat_id=chat_id, message_id=status_message.message_id)
-                    await bot.send_message(chat_id=chat_id, text="تسک شما کامل شد✅", reply_markup=get_main_menu_keyboard())
+                    await bot.send_message(chat_id=chat_id, text="تسک شما کامل شد✅", reply_markup=get_task_done_keyboard())
             except Exception as e:
                 logger.error(f"Celery Gallery-DL Task Error: {e}", exc_info=True)
                 await bot.edit_message_text(text=f"❌ An error occurred: {e}", chat_id=chat_id, message_id=status_message.message_id)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -174,7 +174,8 @@ def download_video(url: str, temp_dir: str, format_id: str) -> str | None:
 
 async def run_gallery_dl_download(url: str, temp_dir: str) -> Tuple[List[str] | None, str | None]:
     logger.info(f"[gallery-dl] Starting download: {url}")
-    command = ['gallery-dl', '-D', temp_dir, url]
+    # Use a simple filename format to avoid issues with long names
+    command = ['gallery-dl', '-D', temp_dir, '--filename', '{id}.{extension}', url]
     process = await asyncio.create_subprocess_exec(*command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
     _, stderr = await process.communicate()
     if process.returncode != 0:

--- a/utils/video_processor.py
+++ b/utils/video_processor.py
@@ -130,5 +130,6 @@ def repair_video(initial_path: str, repaired_path: str) -> bool:
         ffmpeg.input(initial_path).output(repaired_path, c='copy', loglevel='error').run(overwrite_output=True)
         return True
     except ffmpeg.Error as e:
-        logger.error(f"[ffmpeg] Error during stream copy: {e.stderr.decode()}")
+        error_message = e.stderr.decode() if e.stderr else "No stderr output"
+        logger.error(f"[ffmpeg] Error during stream copy: {error_message}")
         return False


### PR DESCRIPTION
1.  **Fix `NameError` in gallery-dl task**: The `process_gallery_dl_task` was calling an incorrect keyboard function (`get_main_menu_keyboard`) after completing a download. This has been corrected to use `get_task_done_keyboard` for consistency.

2.  **Fix `ffmpeg` error with long filenames**: `gallery-dl` was creating filenames that were too long for the filesystem, causing `ffmpeg` to fail with a 'No such file or directory' error. The `run_gallery_dl_download` helper now uses the `--filename '{id}.{extension}'` argument to generate shorter, more reliable filenames.

3.  **Fix `AttributeError` in video processor**: When `ffmpeg` failed, it sometimes produced no `stderr` output. The error logging in `repair_video` would then crash with an `AttributeError` when trying to decode `None`. This has been fixed by adding a check to ensure `e.stderr` exists before decoding.