### PR TITLE
Fix a series of bugs related to downloaders and UI consistency.

### DIFF
--- a/tasks/download_tasks.py
+++ b/tasks/download_tasks.py
@@ -117,7 +117,7 @@ def process_erome_album_task(chat_id: int, user_id: int, album_title: str, media
                 for vid_url in videos_to_dl:
                     download_video_task.delay(chat_id=chat_id, url=vid_url, selected_format='best', video_info_json='{}', user_id=user_id, send_completion_message=False)
         await bot.delete_message(chat_id=chat_id, message_id=status_msg.message_id)
-        await bot.send_message(chat_id=chat_id, text="تسک شما کامل شد✅", reply_markup=get_main_menu_keyboard())
+        await bot.send_message(chat_id=chat_id, text="تسک شما کامل شد✅", reply_markup=get_task_done_keyboard())
     helpers.run_async_in_sync(_async_worker())
 
 @celery_app.task(name="tasks.process_gallery_dl_task")

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -55,15 +55,17 @@ COMICK_DOMAIN = "comick.io"
 PORNHUB_DOMAIN = "pornhub.com"
 EROME_DOMAIN = "erome.com"
 EPORNER_DOMAIN = "eporner.com"
-GALLERY_DL_SITES = ["rule34.xyz", "coomer.st", "aryion.com", "kemono.cr", "tapas.io", "tsumino.com", "danbooru.donmai.us", "e621.net"]
+# rule34.xyz is better handled by yt-dlp for videos
+GALLERY_DL_SITES = ["coomer.st", "aryion.com", "kemono.cr", "tapas.io", "tsumino.com", "danbooru.donmai.us", "e621.net"]
 GALLERY_DL_ZIP_SITES = ["mangadex.org", "e-hentai.org"]
+VIDEO_DOMAINS.append("rule34.xyz") # Add rule34 to video domains
 
 ALL_SUPPORTED_SITES = {
     "Manhwa/Webtoon": [TOONILY_COM_DOMAIN, TOONILY_ME_DOMAIN, MANHWACLAN_DOMAIN, MANGA_DISTRICT_DOMAIN, COMICK_DOMAIN],
     "Gallery/Hentai": GALLERY_DL_SITES + GALLERY_DL_ZIP_SITES,
     "Album": [EROME_DOMAIN],
     "Cosplay": [COSPLAYTELE_DOMAIN],
-    "Video": [PORNHUB_DOMAIN, EPORNER_DOMAIN]
+    "Video": [PORNHUB_DOMAIN, EPORNER_DOMAIN, "rule34.xyz"]
 }
 
 COOKIES_FILE_PATH = "pornhub_cookies.txt"


### PR DESCRIPTION
- **Reroute rule34.xyz to yt-dlp**: `rule34.xyz` links are now handled by `yt-dlp` instead of `gallery-dl`, which was causing file-not-found errors for videos.
- **Fix gallery-dl filename length**: The `gallery-dl` command now uses the `--filename '{id}.{extension}'` argument to prevent creating filenames that are too long for the filesystem.
- **Fix `NameError` in download tasks**: Corrected a `NameError` in `process_gallery_dl_task` and `process_erome_album_task` by using the correct `get_task_done_keyboard` function.
- **Improve ffmpeg error handling**: The `repair_video` function in the video processor now checks if `ffmpeg` error output exists before trying to decode it, preventing an `AttributeError`.
- **Standardize all completion messages**: Ensured that the 'تسک شما انجام شد ✅' message and keyboard are sent consistently after all download, encode, and archive-forwarding tasks.