### PR TITLE
Fix a `NameError` that prevented Celery workers from starting.

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -55,6 +55,7 @@ COMICK_DOMAIN = "comick.io"
 PORNHUB_DOMAIN = "pornhub.com"
 EROME_DOMAIN = "erome.com"
 EPORNER_DOMAIN = "eporner.com"
+VIDEO_DOMAINS = [PORNHUB_DOMAIN, EPORNER_DOMAIN]
 # rule34.xyz is better handled by yt-dlp for videos
 GALLERY_DL_SITES = ["coomer.st", "aryion.com", "kemono.cr", "tapas.io", "tsumino.com", "danbooru.donmai.us", "e621.net"]
 GALLERY_DL_ZIP_SITES = ["mangadex.org", "e-hentai.org"]


### PR DESCRIPTION
The variable `VIDEO_DOMAINS` was being appended to before it was defined in `utils/helpers.py`. This commit defines the list before it is used, resolving the `NameError`.