### PR TITLE
Fix: Finalize application stability by harmonizing bot and task entry…

### DIFF
--- a/bot/core.py
+++ b/bot/core.py
@@ -1,6 +1,5 @@
 from aiogram import Dispatcher
 from aiogram.fsm.storage.memory import MemoryStorage
-from utils.bot_instance import bot 
 from config import settings
 from utils.db_session import AsyncSessionLocal
 from bot.handlers import admin, common, downloader, settings as user_settings, video

--- a/main.py
+++ b/main.py
@@ -2,10 +2,11 @@ import asyncio
 import logging
 import sys
 
-from bot.core import bot, setup_dispatcher
+from bot.core import setup_dispatcher
+from utils.bot_instance import create_bot_instance
 from utils.helpers import check_dependencies
-from utils.db_session import engine 
-from utils.models import Base 
+from utils.db_session import engine
+from utils.models import Base
 
 async def init_database():
     """
@@ -30,17 +31,19 @@ async def main():
     if not check_dependencies():
         logger.error("A required system dependency is missing. Please install it and try again.")
         sys.exit(1)
-        
+
     logger.info("Initializing database...")
     await init_database()
-    
-    # The Telethon authorization check is no longer needed at startup.
-    # It will be handled by the get_or_create_personal_archive function when needed.
 
+    bot = create_bot_instance()
     dp = setup_dispatcher()
 
     logger.info("Starting bot polling...")
-    await dp.start_polling(bot)
+    try:
+        await dp.start_polling(bot)
+    finally:
+        await bot.session.close()
+        logger.info("Bot session closed.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…points

This commit resolves the final `ImportError` that occurred when running the main application via `main.py`. The error was caused by previous refactoring that correctly isolated Celery tasks but did not update the main application's entrypoint to match.

The following changes have been made:

1.  **Refactor `main.py` and `bot/core.py`:**
    - The main application now uses the `create_bot_instance()` factory to create its `Bot` object, mirroring the pattern used in the Celery tasks.
    - The invalid import of the non-existent global `bot` object has been removed from `bot/core.py`.
    - The main application now gracefully closes the bot's session on shutdown.

This change unifies the application's architecture, ensuring that both the main bot process and the Celery workers use the same robust, isolated method for creating and managing `Bot` instances. This resolves all known startup and runtime errors, leading to a stable and reliable application.