### PR TITLE
Feat: Refactor video quality selection workflow

### DIFF
--- a/tasks/video_tasks.py
+++ b/tasks/video_tasks.py
@@ -41,6 +41,22 @@ def encode_video_task(user_id: int, username: str, chat_id: int, video_file_id: 
             custom_thumb_path = None
             applied_tasks = []
 
+            if options.get("selected_quality") and options["selected_quality"] != "original":
+                await bot.edit_message_text(f"🌇 در حال تغییر کیفیت به {options['selected_quality']}p...", chat_id=chat_id, message_id=status_message.message_id)
+                transcoded_path = task_dir / f"transcoded_{final_filename}"
+                success = await asyncio.to_thread(
+                    video_processor.transcode_video,
+                    str(final_video_path),
+                    str(transcoded_path),
+                    int(options["selected_quality"])
+                )
+                if success:
+                    final_video_path = transcoded_path
+                    applied_tasks.append(f"{options['selected_quality']}p")
+                else:
+                    await bot.edit_message_text(f"⚠️ اخطار: تغییر کیفیت انجام نشد، از کیفیت اصلی استفاده می‌شود.", chat_id=chat_id, message_id=status_message.message_id)
+
+
             if options.get("water"):
                 async with AsyncSessionLocal() as session:
                     watermark_settings = await database.get_user_watermark_settings(session, user_id)

--- a/utils/video_processor.py
+++ b/utils/video_processor.py
@@ -133,3 +133,22 @@ def repair_video(initial_path: str, repaired_path: str) -> bool:
         error_message = e.stderr.decode() if e.stderr else "No stderr output"
         logger.error(f"[ffmpeg] Error during stream copy: {error_message}")
         return False
+
+def transcode_video(input_path: str, output_path: str, height: int) -> bool:
+    """
+    Transcodes a video to a specific height, preserving aspect ratio.
+    """
+    logger.info(f"[ffmpeg] Transcoding video to {height}p...")
+    try:
+        (
+            ffmpeg
+            .input(input_path)
+            .output(output_path, vf=f'scale=-2:{height}', preset='fast', crf=24)
+            .overwrite_output()
+            .run(capture_stdout=True, capture_stderr=True)
+        )
+        logger.info(f"Video successfully transcoded to {output_path}")
+        return True
+    except ffmpeg.Error as e:
+        logger.error(f"Error during transcoding: {e.stderr.decode()}", exc_info=True)
+        return False


### PR DESCRIPTION
This commit refactors the video download and encoding process to improve user experience and streamline operations.

Previously, users were prompted to select a video quality immediately after sending a link. This could be slow and confusing, especially for high-resolution videos requiring separate audio/video streams to be merged.

The new workflow is as follows:
1.  **Simplified Download:** The initial quality selection menu has been removed. The bot now automatically downloads the best available quality up to 1080p by default (`bestvideo[height<=1080]+bestaudio/best`). This provides a faster and simpler experience for the most common use case.

2.  **Encoding Quality Options:** The ability to change video quality has been moved to the video encoding panel. A new "Select Quality" button allows the user to choose a specific output resolution (`1080p`, `720p`, etc.) before starting the encoding process.

3.  **Transcoding Logic:** If a user selects a target quality, the `encode_video_task` now performs a re-encoding step using a new `transcode_video` utility function, which leverages `ffmpeg` to scale the video to the desired resolution.

This change separates the initial download from the more advanced encoding options, resulting in a more intuitive and efficient user flow.