### PR TITLE
Fix: Ensure local Bot API is used for file downloads in tasks

### DIFF
--- a/utils/bot_instance.py
+++ b/utils/bot_instance.py
@@ -10,8 +10,11 @@ def create_bot_instance():
     This factory should be called within each async task to ensure session isolation.
     """
     # آدرس سرور محلی را مشخص کنید
+    # Define the data directory from settings
+    data_dir = settings.local_bot_api_server_data_dir if settings.local_bot_api_enabled else None
+
     local_api_server = TelegramAPIServer.from_base(
-        'http://91.107.146.233:8081', is_local=True
+        'http://91.107.146.233:8081', is_local=True, data_dir=data_dir
     )
 
     # یک session جدید با timeout بسیار بالا (مثلاً ۳۰ دقیقه) بسازید


### PR DESCRIPTION
This commit resolves an issue where the bot would use the default Telegram API for downloading files during the encoding task, even when a local Bot API server was configured and active.

The problem was a logical disconnect:
- The `Bot` instance was correctly configured to use the local API.
- The `download_or_copy_file` helper function, however, relied on a separate, independent setting from the environment (`local_bot_api_enabled`) to decide whether to copy the file locally or download it. This setting was not being correctly read in the Celery worker's environment.

This has been fixed by refactoring the logic to be more robust and self-contained:

1.  **`utils/helpers.py`:** The `download_or_copy_file` function no longer reads from `settings`. It now directly inspects the `bot` object passed to it, checking `bot.session.api.is_local` to determine if a local server is in use.

2.  **`utils/bot_instance.py`:** The `create_bot_instance` factory has been updated to explicitly set the `data_dir` on the `TelegramAPIServer` object it creates. This ensures the helper function has access to the correct path for local file copying.

This change guarantees that the file download method is always consistent with the bot's actual runtime configuration, ensuring the faster local file copy method is used whenever possible.