### PR TITLE
Fix: Resolve 'Future attached to a different loop' Error

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -36,17 +36,11 @@ logger = logging.getLogger(__name__)
 # --- Async Runner (FIXED) ---
 def run_async_in_sync(coro: Coroutine):
     """
-    Safely runs an async coroutine from a synchronous context like Celery.
-    It gets the current running loop or creates a new one if none exists
-    for the current OS thread. This approach is crucial for Celery workers
-    where the same process handles multiple tasks sequentially.
+    Safely runs an async coroutine from a synchronous context like Celery by
+    creating a new event loop for each execution. This is the most robust way
+    to prevent "Future attached to a different loop" errors.
     """
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:  # 'RuntimeError: There is no current event loop...'
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    return loop.run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 # --- Domain Constants ---


### PR DESCRIPTION
This commit provides the definitive fix for the `RuntimeError: Task <...> got Future <...> attached to a different loop` that occurred on the second execution of a Celery task.

The root cause was an intricate interaction between the `asyncio` event loops managed by Celery workers and the persistent state of `asyncpg` connections used by SQLAlchemy.

The fix involves refactoring the `run_async_in_sync` helper function in `utils/helpers.py` to use `asyncio.run()`. This is the most robust solution as it guarantees that each Celery task execution, along with its entire async context (including `aiogram`'s bot session and `sqlalchemy`'s connection pool), runs in a completely new and isolated event loop. The loop is created at the start of the task and destroyed at the end, preventing any state from leaking between task runs and resolving the "different loop" error.

This change ensures the long-term stability and reliability of the Celery workers.