### PR TITLE
fix(celery): Initialize database engine per worker to fix event loop …

### DIFF
--- a/tasks/celery_app.py
+++ b/tasks/celery_app.py
@@ -1,10 +1,24 @@
 from celery import Celery
+from celery.signals import worker_process_init
 from dotenv import load_dotenv
+
 from config import settings
+from utils.db_session import initialize_database
 
 # Load environment variables from .env file for Celery workers
 # This is crucial for ensuring workers have access to the same settings as the main app.
 load_dotenv()
+
+@worker_process_init.connect
+def init_worker(**kwargs):
+    """
+    Signal handler to initialize resources for each Celery worker process.
+    This is the key to preventing "event loop" errors with async database
+    connections by ensuring each worker process creates its own engine.
+    """
+    print("Celery worker process initializing...")
+    initialize_database()
+    print("Celery worker process initialization complete.")
 
 # Create the Celery application instance
 celery_app = Celery(

--- a/utils/db_session.py
+++ b/utils/db_session.py
@@ -3,26 +3,43 @@ from sqlalchemy.orm import declarative_base
 
 from config import settings
 
-# Create an asynchronous engine to connect to the PostgreSQL database
-engine = create_async_engine(
-    settings.database_url,
-    future=True,
-    echo=False, # Set to True to see SQL queries in the logs
-)
-
-# Create a session factory for creating new async sessions
-AsyncSessionLocal = async_sessionmaker(
-    engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-)
+# Initialize engine and session factory as None.
+# They will be created by initialize_database() in each worker process.
+engine = None
+AsyncSessionLocal = None
 
 # Base class for our declarative models
 Base = declarative_base()
 
+def initialize_database():
+    """
+    Initializes the database engine and session factory.
+    This function should be called once per process (e.g., in a Celery worker).
+    """
+    global engine, AsyncSessionLocal
+
+    if engine is None:
+        print("Initializing database engine...")
+        engine = create_async_engine(
+            settings.database_url,
+            future=True,
+            echo=False,  # Set to True for debugging SQL queries
+        )
+        AsyncSessionLocal = async_sessionmaker(
+            engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+        print("Database engine initialized.")
+
 async def get_db_session() -> AsyncSession:
     """
     Dependency function that yields a new SQLAlchemy async session.
+    Ensures that the database is initialized before creating a session.
     """
+    if AsyncSessionLocal is None:
+        # This is a fallback in case initialization didn't run.
+        initialize_database()
+
     async with AsyncSessionLocal() as session:
         yield session


### PR DESCRIPTION
…error

Refactored the database session management to prevent asyncio event loop conflicts when using Celery with a forked process model.

Previously, the SQLAlchemy async engine was created as a global singleton when the `utils.db_session` module was imported. This caused a `RuntimeError: ... attached to a different loop` because the engine, tied to the main process's event loop, was inherited by forked Celery worker processes, each of which runs its own separate event loop.

This commit resolves the issue by:
1.  Modifying `utils/db_session.py` to support lazy initialization. The `engine` and `AsyncSessionLocal` are now `None` by default and are created by a new `initialize_database()` function.
2.  Using the `worker_process_init` signal in `tasks/celery_app.py` to call `initialize_database()` whenever a new worker process is started.

This ensures that each Celery worker process creates and uses its own database engine, correctly associating it with its own event loop and resolving the conflict.