### PR TITLE
Add thumbnail management panel and multi-thumbnail selection

### DIFF
--- a/bot/handlers/settings.py
+++ b/bot/handlers/settings.py
@@ -5,13 +5,36 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from utils import database
+from utils import database, models
 
 router = Router()
 
 # --- Thumbnail FSM ---
 class ThumbnailFSM(StatesGroup):
+    panel = State()
     awaiting_photo = State()
+    awaiting_delete_choice = State()
+
+
+async def get_thumbnail_panel(session: AsyncSession, user_id: int) -> tuple[str, InlineKeyboardMarkup, list[models.Thumbnail]]:
+    thumbnails = await database.get_user_thumbnails(session, user_id)
+    count = len(thumbnails)
+
+    text = (
+        "برای تنظیم واترمارک لطفا یک عکس بفرستید، و برای مدیریت واترمارک از دکمه های زیر استفاده کنید، دستور /cancel برای لغو عملیات"
+        f"\n\n✅ تعداد تامبنیل‌های فعلی شما: {count} از 10"
+    )
+
+    buttons: list[list[InlineKeyboardButton]] = []
+    if thumbnails:
+        buttons.append([InlineKeyboardButton(text="حذف تامبنیل", callback_data="thumb_delete")])
+    if count < 10:
+        buttons.append([InlineKeyboardButton(text="اضافه کردن تامبنیل", callback_data="thumb_add")])
+    if not buttons:
+        buttons.append([InlineKeyboardButton(text="اضافه کردن تامبنیل", callback_data="thumb_add")])
+
+    keyboard = InlineKeyboardMarkup(inline_keyboard=buttons)
+    return text, keyboard, thumbnails
 
 @router.message(Command("thumb"))
 async def thumb_entry(message: types.Message, state: FSMContext, session: AsyncSession):
@@ -20,22 +43,90 @@ async def thumb_entry(message: types.Message, state: FSMContext, session: AsyncS
         await message.answer("You do not have permission to use the thumbnail feature.")
         return
 
-    await message.answer("Please send a photo to set as a thumbnail, or type /cancel to abort.")
+    text, keyboard, _ = await get_thumbnail_panel(session, message.from_user.id)
+    await message.answer(text, reply_markup=keyboard)
+    await state.set_state(ThumbnailFSM.panel)
+
+
+@router.callback_query(ThumbnailFSM.panel, F.data == "thumb_add")
+async def thumb_add(query: types.CallbackQuery, state: FSMContext, session: AsyncSession):
+    thumbnails = await database.get_user_thumbnails(session, query.from_user.id)
+    if len(thumbnails) >= 10:
+        await query.answer("شما نمی‌توانید بیش از ۱۰ تامبنیل فعال داشته باشید.", show_alert=True)
+        return
+
     await state.set_state(ThumbnailFSM.awaiting_photo)
+    await query.message.edit_text("لطفاً یک عکس ارسال کنید تا به لیست تامبنیل‌ها اضافه شود. برای لغو /cancel را ارسال کنید.")
+    await query.answer()
+
+
+@router.callback_query(ThumbnailFSM.panel, F.data == "thumb_delete")
+async def thumb_delete(query: types.CallbackQuery, state: FSMContext, session: AsyncSession):
+    _, _, thumbnails = await get_thumbnail_panel(session, query.from_user.id)
+    if not thumbnails:
+        await query.answer("شما هیچ تامبنیلی برای حذف ندارید.", show_alert=True)
+        return
+
+    buttons = [
+        [InlineKeyboardButton(text=f"تامبنیل {index + 1}", callback_data=f"thumb_del_{thumb.id}")]
+        for index, thumb in enumerate(thumbnails)
+    ]
+    buttons.append([InlineKeyboardButton(text="🔙 بازگشت", callback_data="thumb_del_back")])
+
+    await state.set_state(ThumbnailFSM.awaiting_delete_choice)
+    await query.message.edit_text(
+        "لطفاً تامبنیل مورد نظر برای حذف را انتخاب کنید:",
+        reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
+    )
+    await query.answer()
 
 @router.message(ThumbnailFSM.awaiting_photo, F.photo)
 async def receive_thumbnail(message: types.Message, state: FSMContext, session: AsyncSession):
     """Receives the photo and sets it as the user's thumbnail."""
     # The last photo in the list is usually the highest quality
     file_id = message.photo[-1].file_id
-    await database.set_user_thumbnail(session, user_id=message.from_user.id, file_id=file_id)
-    await message.answer("✅ Thumbnail set successfully!")
-    await state.clear()
+    try:
+        await database.set_user_thumbnail(session, user_id=message.from_user.id, file_id=file_id)
+        await message.answer("✅ تامبنیل جدید با موفقیت اضافه شد.")
+    except ValueError:
+        await message.answer("⚠️ شما به حداکثر تعداد مجاز (۱۰) تامبنیل رسیده‌اید.")
+
+    text, keyboard, _ = await get_thumbnail_panel(session, message.from_user.id)
+    await message.answer(text, reply_markup=keyboard)
+    await state.set_state(ThumbnailFSM.panel)
 
 @router.message(ThumbnailFSM.awaiting_photo)
 async def incorrect_thumbnail_input(message: types.Message):
     """Handles cases where the user sends something other than a photo."""
-    await message.answer("Invalid input. Please send a photo or cancel with /cancel.")
+    await message.answer("ورودی نامعتبر است. لطفاً یک عکس ارسال کنید یا با /cancel عملیات را لغو کنید.")
+
+
+@router.callback_query(ThumbnailFSM.awaiting_delete_choice, F.data == "thumb_del_back")
+async def thumb_delete_back(query: types.CallbackQuery, state: FSMContext, session: AsyncSession):
+    text, keyboard, _ = await get_thumbnail_panel(session, query.from_user.id)
+    await state.set_state(ThumbnailFSM.panel)
+    await query.message.edit_text(text, reply_markup=keyboard)
+    await query.answer()
+
+
+@router.callback_query(ThumbnailFSM.awaiting_delete_choice, F.data.startswith("thumb_del_"))
+async def thumb_delete_confirm(query: types.CallbackQuery, state: FSMContext, session: AsyncSession):
+    thumb_id_str = query.data.replace("thumb_del_", "")
+    try:
+        thumb_id = int(thumb_id_str)
+    except ValueError:
+        await query.answer("شناسه تامبنیل نامعتبر است.", show_alert=True)
+        return
+
+    deleted = await database.delete_user_thumbnail(session, query.from_user.id, thumb_id)
+    if not deleted:
+        await query.answer("این تامبنیل پیدا نشد یا قبلاً حذف شده است.", show_alert=True)
+        return
+
+    await query.answer("تامبنیل حذف شد.")
+    text, keyboard, _ = await get_thumbnail_panel(session, query.from_user.id)
+    await state.set_state(ThumbnailFSM.panel)
+    await query.message.edit_text(text, reply_markup=keyboard)
 
 
 # --- Watermark FSM ---

--- a/tasks/video_tasks.py
+++ b/tasks/video_tasks.py
@@ -68,9 +68,10 @@ def encode_video_task(user_id: int, username: str, chat_id: int, video_file_id: 
                         final_video_path = watermarked_path
                         applied_tasks.append("water")
 
-            if options.get("thumb"):
+            if options.get("thumb") and options.get("thumb_id"):
                 async with AsyncSessionLocal() as session:
-                    thumbnail_id = await database.get_user_thumbnail(session, user_id)
+                    thumbnail = await database.get_user_thumbnail_by_id(session, user_id, options["thumb_id"])
+                thumbnail_id = thumbnail.file_id if thumbnail else None
                 if thumbnail_id:
                     await bot.edit_message_text("🖼️ در حال دریافت تامبنیل...", chat_id=chat_id, message_id=status_message.message_id)
                     thumb_file = await bot.get_file(thumbnail_id)

--- a/utils/db_session.py
+++ b/utils/db_session.py
@@ -1,5 +1,6 @@
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.orm import declarative_base
+from sqlalchemy.pool import NullPool
 
 from config import settings
 
@@ -7,7 +8,8 @@ from config import settings
 engine = create_async_engine(
     settings.database_url,
     future=True,
-    echo=False, # Set to True to see SQL queries in the logs
+    echo=False,  # Set to True to see SQL queries in the logs
+    poolclass=NullPool,  # Prevent reusing connections across event loops
 )
 
 # Create a session factory for creating new async sessions

--- a/utils/models.py
+++ b/utils/models.py
@@ -34,7 +34,12 @@ class User(Base):
     stats_site_usage = Column(JSONB)
 
     # Relationships
-    thumbnail = relationship("Thumbnail", back_populates="user", uselist=False)
+    thumbnails = relationship(
+        "Thumbnail",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        order_by="Thumbnail.id",
+    )
     watermark = relationship("WatermarkSetting", back_populates="user", uselist=False)
 
 
@@ -45,7 +50,7 @@ class Thumbnail(Base):
     id = Column(Integer, primary_key=True)
     user_id = Column(BigInteger, ForeignKey('public.users.id'), nullable=False)
     file_id = Column(String, nullable=False)
-    user = relationship("User", back_populates="thumbnail")
+    user = relationship("User", back_populates="thumbnails")
 
 
 class WatermarkSetting(Base):


### PR DESCRIPTION
## Summary
- add a control panel for /thumb with inline buttons to add or remove up to ten thumbnails per user
- support selecting a specific thumbnail when enabling thumbnail application during encoding
- persist multiple thumbnails per user in the database and reuse them in the encoding task

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d5894eb304832bad0dab79b36dd5be