### PR TITLE
Implement daily task usage tracking and limit enforcement

### DIFF
--- a/bot/handlers/video.py
+++ b/bot/handlers/video.py
@@ -213,6 +213,13 @@ async def handle_start_button(query: types.CallbackQuery, state: FSMContext, ses
         await query.answer("خطا: شما اعمال واترمارک را انتخاب کرده‌اید اما واترمارک شما غیرفعال است. لطفاً با /water آن را فعال کنید و دوباره امتحان کنید.", show_alert=True)
         return
 
+    can_start, limit, used_today = await database.can_user_start_task(session, user_id)
+    if not can_start:
+        await query.answer(database.format_task_limit_message(limit, used_today), show_alert=True)
+        return
+
+    await database.record_task_usage(session, user_id, "encode")
+
     await query.message.edit_text("✅ درخواست شما به صف انکد اضافه شد...")
     video_tasks.encode_video_task.delay(
         user_id=user_id,

--- a/create_tables.py
+++ b/create_tables.py
@@ -13,6 +13,7 @@ from utils.models import (
     PublicArchive,
     BotText,
     DownloadRecord,
+    TaskUsage,
 )
 
 async def create_db_tables():

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -111,6 +111,10 @@ async def check_subscription(session: AsyncSession, user_id: int, domain: str) -
     if not user.sub_allowed_sites.get(domain, False):
         return False, f"Your subscription does not include access to {domain}."
 
+    can_start, limit, used_today = await database.can_user_start_task(session, user_id)
+    if not can_start:
+        return False, database.format_task_limit_message(limit, used_today)
+
     return True, "Access granted."
 
 

--- a/utils/models.py
+++ b/utils/models.py
@@ -50,6 +50,12 @@ class User(Base):
         cascade="all, delete-orphan",
         order_by="DownloadRecord.id",
     )
+    task_usage = relationship(
+        "TaskUsage",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        order_by="TaskUsage.id",
+    )
 
 
 class Thumbnail(Base):
@@ -122,3 +128,15 @@ class DownloadRecord(Base):
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
 
     user = relationship("User", back_populates="download_records")
+
+
+class TaskUsage(Base):
+    __tablename__ = "task_usage"
+    __table_args__ = {"schema": "public"}
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(BigInteger, ForeignKey("public.users.id"), nullable=False, index=True)
+    task_type = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    user = relationship("User", back_populates="task_usage")


### PR DESCRIPTION
## Summary
- add a TaskUsage model and supporting helpers to track daily task consumption and format limit messages
- enforce daily subscription task limits before queuing download and encode jobs, recording usage for each request

## Testing
- python -m compileall bot utils tasks

------
https://chatgpt.com/codex/tasks/task_e_68d6a0d20b24832bb50a6cc6e649c243