### PR TITLE
Expand thumbnail and watermark management

### DIFF
--- a/tasks/video_tasks.py
+++ b/tasks/video_tasks.py
@@ -54,9 +54,11 @@ def encode_video_task(user_id: int, username: str, chat_id: int, video_file_id: 
                 else:
                     await bot.edit_message_text(f"⚠️ اخطار: تغییر کیفیت انجام نشد، از کیفیت اصلی استفاده می‌شود.", chat_id=chat_id, message_id=status_message.message_id)
 
-            if options.get("water"):
+            if options.get("water") and options.get("watermark_id"):
                 async with AsyncSessionLocal() as session:
-                    watermark_settings = await database.get_user_watermark_settings(session, user_id)
+                    watermark_settings = await database.get_user_watermark_by_id(
+                        session, user_id, options["watermark_id"]
+                    )
                 if watermark_settings and watermark_settings.enabled:
                     await bot.edit_message_text("💧 در حال اعمال واترمارک...", chat_id=chat_id, message_id=status_message.message_id)
                     watermarked_path = task_dir / f"watermarked_{final_filename}"

--- a/utils/models.py
+++ b/utils/models.py
@@ -43,7 +43,12 @@ class User(Base):
         cascade="all, delete-orphan",
         order_by="Thumbnail.id",
     )
-    watermark = relationship("WatermarkSetting", back_populates="user", uselist=False)
+    watermarks = relationship(
+        "WatermarkSetting",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        order_by="WatermarkSetting.id",
+    )
     download_records = relationship(
         "DownloadRecord",
         back_populates="user",
@@ -65,6 +70,7 @@ class Thumbnail(Base):
     id = Column(Integer, primary_key=True)
     user_id = Column(BigInteger, ForeignKey('public.users.id'), nullable=False)
     file_id = Column(String, nullable=False)
+    display_name = Column(String, nullable=True)
     user = relationship("User", back_populates="thumbnails")
 
 
@@ -73,14 +79,15 @@ class WatermarkSetting(Base):
     __table_args__ = {"schema": "public"}
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(BigInteger, ForeignKey("public.users.id"), unique=True, nullable=False)
-    enabled = Column(Boolean, default=False)
+    user_id = Column(BigInteger, ForeignKey("public.users.id"), nullable=False, index=True)
+    display_name = Column(String, nullable=True)
+    enabled = Column(Boolean, default=True)
     text = Column(String, default="@YourBot")
     position = Column(String, default="top_left")
     size = Column(Integer, default=32)
     color = Column(String, default="white")
     stroke = Column(Integer, default=2)
-    user = relationship("User", back_populates="watermark")
+    user = relationship("User", back_populates="watermarks")
 
 
 class UrlCache(Base):


### PR DESCRIPTION
## Summary
- Allow users to store up to 50 thumbnails, prompting for optional display names during upload so presets are easier to identify and manage.
- Replace the single watermark setting with a multi-profile manager that supports naming, selection, editing, and deletion of up to 50 watermarks.
- Update the encode workflow and background task to honor the selected thumbnail and watermark choices, including display names and enabled status.

## Testing
- python -m compileall bot utils tasks

------
https://chatgpt.com/codex/tasks/task_e_68d6a8fa9018832b934a123e93b3f47f