### PR TITLE
Ensure custom thumbnails meet Telegram requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ sqlalchemy[asyncio]
 asyncpg
 psycopg2-binary
 alembic
+Pillow

--- a/tasks/video_tasks.py
+++ b/tasks/video_tasks.py
@@ -79,7 +79,18 @@ def encode_video_task(user_id: int, username: str, chat_id: int, video_file_id: 
                     thumb_file = await bot.get_file(thumbnail_id)
                     custom_thumb_path = task_dir / f"thumb_{user_id}.jpg"
                     await helpers.download_or_copy_file(bot, thumb_file, custom_thumb_path)
-                    applied_tasks.append("thumb")
+                    thumb_ready = await asyncio.to_thread(
+                        video_processor.prepare_thumbnail_image,
+                        custom_thumb_path,
+                    )
+                    if thumb_ready:
+                        applied_tasks.append("thumb")
+                    else:
+                        logger.warning(
+                            "Custom thumbnail for user %s could not be prepared and will be skipped.",
+                            user_id,
+                        )
+                        custom_thumb_path = None
 
             await bot.edit_message_text("📤 در حال آپلود ویدیوی نهایی...", chat_id=chat_id, message_id=status_message.message_id)
             duration, width, height = await asyncio.to_thread(video_processor.get_video_metadata, str(final_video_path))


### PR DESCRIPTION
## Summary
- add Pillow dependency and thumbnail preparation helper to keep images within Telegram size and format limits
- normalize downloaded thumbnails before sending videos so invalid thumbnails are skipped gracefully
- reuse the preparation logic when uploading videos through the shared Telegram API helper

## Testing
- python -m compileall tasks/video_tasks.py utils/video_processor.py utils/telegram_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c22792e8832ba0ec8663f063998e