### PR TITLE
Remove inline buttons from completion messages

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -33,11 +33,8 @@ def get_main_reply_keyboard():
     )
 
 def get_task_done_keyboard():
-    """Returns the keyboard for the task done message."""
-    return InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="📥 ارسال لینک جدید", callback_data="start_download")],
-        [InlineKeyboardButton(text="🎬 ارسال ویدیوی جدید", callback_data="start_encode")]
-    ])
+    """Legacy helper kept for compatibility; no keyboard is attached now."""
+    return None
 
 @router.message(CommandStart())
 async def handle_start(message: types.Message, state: FSMContext, session: AsyncSession):


### PR DESCRIPTION
## Summary
- stop attaching the legacy inline keyboard to task completion messages by making the helper return `None`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6cf024348832b82d1c3833706b8b0