### PR TITLE
Separate download and encode task limits

### DIFF
--- a/bot/handlers/downloader.py
+++ b/bot/handlers/downloader.py
@@ -109,9 +109,9 @@ async def auto_start_download(message: types.Message, state: FSMContext, session
 
 
 async def _reserve_task_slot(session: AsyncSession, user_id: int, task_type: str = "download") -> tuple[bool, str | None]:
-    allowed, limit, used_today = await database.can_user_start_task(session, user_id)
+    allowed, limit, used_today = await database.can_user_start_task(session, user_id, task_type=task_type)
     if not allowed:
-        return False, database.format_task_limit_message(limit, used_today)
+        return False, database.format_task_limit_message(task_type, limit, used_today)
 
     await database.record_task_usage(session, user_id, task_type)
     return True, None

--- a/bot/handlers/video.py
+++ b/bot/handlers/video.py
@@ -269,9 +269,9 @@ async def handle_start_button(query: types.CallbackQuery, state: FSMContext, ses
             await query.answer("واترمارک انتخاب‌شده غیرفعال است. لطفاً از /water آن را فعال کنید.", show_alert=True)
             return
 
-    can_start, limit, used_today = await database.can_user_start_task(session, user_id)
+    can_start, limit, used_today = await database.can_user_start_task(session, user_id, task_type="encode")
     if not can_start:
-        await query.answer(database.format_task_limit_message(limit, used_today), show_alert=True)
+        await query.answer(database.format_task_limit_message("encode", limit, used_today), show_alert=True)
         return
 
     await database.record_task_usage(session, user_id, "encode")

--- a/create_tables.py
+++ b/create_tables.py
@@ -1,4 +1,5 @@
 import asyncio
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from config import settings
@@ -26,6 +27,18 @@ async def create_db_tables():
     async with engine.begin() as conn:
         print("Creating all tables based on models (if they don't exist)...")
         await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(text(
+            "ALTER TABLE IF EXISTS public.users "
+            "ADD COLUMN IF NOT EXISTS sub_encode_limit INTEGER DEFAULT -1"
+        ))
+        await conn.execute(text(
+            "ALTER TABLE public.users "
+            "ALTER COLUMN sub_encode_limit SET DEFAULT -1"
+        ))
+        await conn.execute(text(
+            "UPDATE public.users SET sub_encode_limit = -1 "
+            "WHERE sub_encode_limit IS NULL"
+        ))
 
     print("Tables created successfully.")
     await engine.dispose()

--- a/main.py
+++ b/main.py
@@ -3,6 +3,8 @@ import logging
 import sys
 
 from bot.core import setup_dispatcher
+from sqlalchemy import text
+
 from utils.bot_instance import create_bot_instance
 from utils.helpers import check_dependencies
 from utils.db_session import engine
@@ -14,6 +16,18 @@ async def init_database():
     """
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await conn.execute(text(
+            "ALTER TABLE IF EXISTS public.users "
+            "ADD COLUMN IF NOT EXISTS sub_encode_limit INTEGER DEFAULT -1"
+        ))
+        await conn.execute(text(
+            "ALTER TABLE public.users "
+            "ALTER COLUMN sub_encode_limit SET DEFAULT -1"
+        ))
+        await conn.execute(text(
+            "UPDATE public.users SET sub_encode_limit = -1 "
+            "WHERE sub_encode_limit IS NULL"
+        ))
     logging.getLogger(__name__).info("Database tables checked/created successfully.")
 
 async def main():

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -118,9 +118,9 @@ async def check_subscription(session: AsyncSession, user_id: int, domain: str) -
     if not user.sub_allowed_sites.get(domain, False):
         return False, f"Your subscription does not include access to {domain}."
 
-    can_start, limit, used_today = await database.can_user_start_task(session, user_id)
+    can_start, limit, used_today = await database.can_user_start_task(session, user_id, task_type="download")
     if not can_start:
-        return False, database.format_task_limit_message(limit, used_today)
+        return False, database.format_task_limit_message("download", limit, used_today)
 
     return True, "Access granted."
 

--- a/utils/models.py
+++ b/utils/models.py
@@ -29,6 +29,7 @@ class User(Base):
     sub_is_active = Column(Boolean, default=False)
     sub_expiry_date = Column(DateTime, nullable=True)
     sub_download_limit = Column(Integer, default=-1)
+    sub_encode_limit = Column(Integer, default=-1)
     sub_allowed_sites = Column(JSONB)
 
     allow_thumbnail = Column(Boolean, default=True, nullable=False)


### PR DESCRIPTION
## Summary
- add a dedicated encode limit column to user records and ensure databases backfill it automatically
- split task quota checks and messaging to track download and encode usage independently
- expose separate daily limit controls for downloads and encodes in the admin subscription panel

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68d6f9269184832ba7012fdafe0760ac