### PR TITLE
Add crypto subscription payments with admin management

### DIFF
--- a/bot/core.py
+++ b/bot/core.py
@@ -1,7 +1,7 @@
 from aiogram import Dispatcher, Bot
 from aiogram.fsm.storage.memory import MemoryStorage
 from utils.db_session import AsyncSessionLocal
-from bot.handlers import admin, common, downloader, settings as user_settings, video
+from bot.handlers import admin, common, downloader, payments, settings as user_settings, video
 from bot.middlewares import DbSessionMiddleware
 
 
@@ -19,6 +19,7 @@ def setup_dispatcher() -> Dispatcher:
     # Include all the routers from the handlers package
     dp.include_router(common.router)
     dp.include_router(admin.router)
+    dp.include_router(payments.router)
     dp.include_router(user_settings.router)
     dp.include_router(video.router)
     dp.include_router(downloader.router) # This should be last as it has a broad regex

--- a/bot/handlers/payments.py
+++ b/bot/handlers/payments.py
@@ -1,0 +1,216 @@
+import asyncio
+import logging
+from typing import Iterable
+
+from aiogram import Bot, F, Router, types
+from aiogram.filters import Command
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, CallbackQuery
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils import database
+from utils.db_session import AsyncSessionLocal
+from utils.payments import (
+    create_nowpayments_payment,
+    get_live_price,
+    get_nowpayments_payment_status,
+)
+
+logger = logging.getLogger(__name__)
+
+router = Router()
+
+PAYMENT_CURRENCY = "trx"
+STATUS_SUCCESS = {"finished", "confirmed", "completed", "paid"}
+STATUS_FAILED = {"failed", "expired", "refunded", "partially_refunded"}
+CHECK_INTERVAL_SECONDS = 20
+MAX_STATUS_CHECKS = 45  # ~15 minutes
+
+
+def _format_plan_description(plan, *, crypto_amount: float) -> str:
+    download_limit = "نامحدود" if plan.download_limit == -1 else f"{plan.download_limit}"
+    encode_limit = "نامحدود" if plan.encode_limit == -1 else f"{plan.encode_limit}"
+    return (
+        f"{plan.title}\n"
+        f"مدت: {plan.duration_days} روز\n"
+        f"دانلود روزانه: {download_limit}\n"
+        f"انکد روزانه: {encode_limit}\n"
+        f"قیمت: {plan.price_toman:,} تومان (~{crypto_amount} {PAYMENT_CURRENCY.upper()})"
+    )
+
+
+def _build_plans_keyboard(plans: Iterable, *, price_per_coin: float) -> InlineKeyboardMarkup:
+    buttons = []
+    for plan in plans:
+        crypto_amount = round(plan.price_toman / price_per_coin, 6)
+        buttons.append([
+            InlineKeyboardButton(
+                text=f"{plan.title} ({crypto_amount} {PAYMENT_CURRENCY.upper()})",
+                callback_data=f"buy_plan_{plan.id}",
+            )
+        ])
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+@router.message(Command("buy"))
+async def show_buy_menu(message: types.Message, session: AsyncSession):
+    plans = await database.list_subscription_plans(session)
+    if not plans:
+        await message.answer("در حال حاضر اشتراکی برای خرید فعال نیست. لطفاً بعداً تلاش کنید.")
+        return
+
+    try:
+        price_per_coin = await get_live_price(PAYMENT_CURRENCY)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load live price: %s", exc)
+        await message.answer("دریافت قیمت لحظه‌ای با خطا مواجه شد. لطفاً کمی بعد دوباره تلاش کنید.")
+        return
+
+    descriptions = [
+        _format_plan_description(plan, crypto_amount=round(plan.price_toman / price_per_coin, 6))
+        for plan in plans
+    ]
+
+    keyboard = _build_plans_keyboard(plans, price_per_coin=price_per_coin)
+    text = "پلن مورد نظر خود را انتخاب کنید:\n\n" + "\n\n".join(descriptions)
+    await message.answer(text, reply_markup=keyboard)
+
+
+async def _poll_payment_status(*, bot: Bot, payment_id: str, user_id: int, plan_id: int, api_key: str) -> None:
+    attempts = 0
+    while attempts < MAX_STATUS_CHECKS:
+        await asyncio.sleep(CHECK_INTERVAL_SECONDS)
+        attempts += 1
+
+        try:
+            payment_info = await get_nowpayments_payment_status(api_key=api_key, payment_id=payment_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to fetch payment status for %s: %s", payment_id, exc)
+            continue
+
+        status = payment_info.get("payment_status") or payment_info.get("status")
+        if not status:
+            continue
+
+        async with AsyncSessionLocal() as new_session:
+            await database.update_payment_transaction_status(
+                new_session,
+                payment_id=payment_id,
+                status=status,
+            )
+
+            if status.lower() in STATUS_SUCCESS:
+                plan = await database.get_subscription_plan(new_session, plan_id)
+                if not plan:
+                    await bot.send_message(user_id, "پلن خریداری‌شده دیگر وجود ندارد. لطفاً با پشتیبانی تماس بگیرید.")
+                    return
+
+                user = await database.apply_subscription_plan(new_session, user_id=user_id, plan=plan)
+                await bot.send_message(
+                    user_id,
+                    (
+                        "پرداخت شما با موفقیت تأیید شد.\n"
+                        f"اشتراک شما تا تاریخ {user.sub_expiry_date:%Y-%m-%d} فعال شد."
+                    ),
+                )
+                return
+
+            if status.lower() in STATUS_FAILED:
+                await bot.send_message(
+                    user_id,
+                    "پرداخت ناموفق بود یا منقضی شده است. در صورت کسر وجه، با پشتیبانی تماس بگیرید.",
+                )
+                return
+
+    # Timed out
+    async with AsyncSessionLocal() as new_session:
+        await database.update_payment_transaction_status(
+            new_session,
+            payment_id=payment_id,
+            status="timeout",
+        )
+    await bot.send_message(
+        user_id,
+        "وضعیت پرداخت طی زمان مقرر مشخص نشد. لطفاً در صورت انجام پرداخت با پشتیبانی تماس بگیرید.",
+    )
+
+
+@router.callback_query(F.data.startswith("buy_plan_"))
+async def handle_plan_purchase(query: CallbackQuery, session: AsyncSession):
+    await query.answer()
+
+    try:
+        plan_id = int(query.data.replace("buy_plan_", ""))
+    except ValueError:
+        await query.message.answer("پلن انتخابی نامعتبر است.")
+        return
+
+    plan = await database.get_subscription_plan(session, plan_id)
+    if not plan or not plan.is_active:
+        await query.message.answer("این پلن در حال حاضر فعال نیست.")
+        return
+
+    api_key = await database.get_payment_setting(session, "nowpayments_api_key")
+    if not api_key:
+        await query.message.answer("درگاه پرداخت موقتاً در دسترس نیست. لطفاً با پشتیبانی تماس بگیرید.")
+        return
+
+    try:
+        price_per_coin = await get_live_price(PAYMENT_CURRENCY)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load live price: %s", exc)
+        await query.message.answer("دریافت قیمت لحظه‌ای با خطا مواجه شد. لطفاً کمی بعد دوباره تلاش کنید.")
+        return
+
+    crypto_amount = round(plan.price_toman / price_per_coin, 6)
+    loop = asyncio.get_running_loop()
+    order_id = f"{query.from_user.id}-{plan.id}-{int(loop.time() * 1000)}"
+
+    try:
+        payment_response = await create_nowpayments_payment(
+            api_key=api_key,
+            amount=crypto_amount,
+            currency=PAYMENT_CURRENCY,
+            order_id=order_id,
+            description=f"Plan {plan.title}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to create payment: %s", exc)
+        await query.message.answer("ایجاد پرداخت با خطا مواجه شد. لطفاً کمی بعد دوباره تلاش کنید.")
+        return
+
+    payment_id = str(payment_response.get("payment_id"))
+    invoice_url = payment_response.get("invoice_url") or payment_response.get("pay_url")
+    pay_amount = payment_response.get("pay_amount", crypto_amount)
+    pay_currency = payment_response.get("pay_currency", PAYMENT_CURRENCY)
+
+    if not payment_id or not invoice_url:
+        logger.error("Unexpected payment response: %s", payment_response)
+        await query.message.answer("خطای غیرمنتظره‌ای رخ داد. لطفاً با پشتیبانی تماس بگیرید.")
+        return
+
+    await database.create_payment_transaction(
+        session,
+        user_id=query.from_user.id,
+        plan_id=plan.id,
+        payment_id=payment_id,
+        invoice_url=invoice_url,
+        pay_amount=str(pay_amount),
+        pay_currency=pay_currency,
+    )
+
+    text = (
+        "برای تکمیل خرید روی لینک زیر کلیک کنید و مبلغ را پرداخت نمایید:\n"
+        f"لینک پرداخت: {invoice_url}\n"
+        f"مبلغ قابل پرداخت: {pay_amount} {pay_currency.upper()}"
+    )
+    await query.message.answer(text)
+
+    asyncio.create_task(
+        _poll_payment_status(
+            bot=query.message.bot,
+            payment_id=payment_id,
+            user_id=query.from_user.id,
+            plan_id=plan.id,
+            api_key=api_key,
+        )
+    )

--- a/create_tables.py
+++ b/create_tables.py
@@ -15,6 +15,9 @@ from utils.models import (
     BotText,
     DownloadRecord,
     TaskUsage,
+    SubscriptionPlan,
+    PaymentSetting,
+    PaymentTransaction,
 )
 
 async def create_db_tables():

--- a/utils/models.py
+++ b/utils/models.py
@@ -62,6 +62,12 @@ class User(Base):
         cascade="all, delete-orphan",
         order_by="TaskUsage.id",
     )
+    payments = relationship(
+        "PaymentTransaction",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        order_by="PaymentTransaction.id",
+    )
 
 
 class Thumbnail(Base):
@@ -148,3 +154,48 @@ class TaskUsage(Base):
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
 
     user = relationship("User", back_populates="task_usage")
+
+
+class SubscriptionPlan(Base):
+    __tablename__ = "subscription_plans"
+    __table_args__ = {"schema": "public"}
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    duration_days = Column(Integer, nullable=False)
+    download_limit = Column(Integer, nullable=False)
+    encode_limit = Column(Integer, nullable=False)
+    price_toman = Column(Integer, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    payments = relationship("PaymentTransaction", back_populates="plan")
+
+
+class PaymentSetting(Base):
+    __tablename__ = "payment_settings"
+    __table_args__ = {"schema": "public"}
+
+    key = Column(String, primary_key=True)
+    value = Column(String, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+
+class PaymentTransaction(Base):
+    __tablename__ = "payment_transactions"
+    __table_args__ = {"schema": "public"}
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(BigInteger, ForeignKey("public.users.id"), nullable=False, index=True)
+    plan_id = Column(Integer, ForeignKey("public.subscription_plans.id"), nullable=False)
+    payment_id = Column(String, unique=True, nullable=False)
+    invoice_url = Column(String, nullable=False)
+    pay_amount = Column(String, nullable=False)
+    pay_currency = Column(String, nullable=False)
+    status = Column(String, default="waiting", nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    user = relationship("User", back_populates="payments")
+    plan = relationship("SubscriptionPlan", back_populates="payments")

--- a/utils/payments.py
+++ b/utils/payments.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+from typing import Any, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+BITPIN_MARKETS_URL = "https://api.bitpin.ir/v1/mkt/markets/"
+NOBITEX_STATS_URL = "https://api.nobitex.ir/market/stats"
+NOWPAYMENTS_API_BASE = "https://api.nowpayments.io/v1"
+
+
+async def _async_request(method: str, url: str, **kwargs) -> requests.Response:
+    timeout = kwargs.pop("timeout", 15)
+    return await asyncio.to_thread(requests.request, method, url, timeout=timeout, **kwargs)
+
+
+async def fetch_nobitex_price(symbol: str = "trx", currency: str = "rls") -> Optional[float]:
+    params = {"srcCurrency": symbol, "dstCurrency": currency}
+    try:
+        response = await _async_request("get", NOBITEX_STATS_URL, params=params)
+        response.raise_for_status()
+        data = response.json()
+        market_key = f"{symbol}-{currency}"
+        stats = data.get("stats", {}).get(market_key)
+        if not stats:
+            return None
+        latest_price = stats.get("latest")
+        if not latest_price:
+            return None
+        price = float(latest_price)
+        if currency.lower() == "rls":
+            price /= 10  # Convert from Rial to Toman
+        return price
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to fetch Nobitex price: %s", exc)
+        return None
+
+
+async def fetch_bitpin_price(symbol: str = "trx", currency: str = "irt") -> Optional[float]:
+    try:
+        response = await _async_request("get", BITPIN_MARKETS_URL)
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to fetch Bitpin price: %s", exc)
+        return None
+
+    for market in payload.get("results", []):
+        base = market.get("currency1", {}).get("code", "").lower()
+        quote = market.get("currency2", {}).get("code", "").lower()
+        if base == symbol.lower() and quote == currency.lower():
+            try:
+                return float(market.get("price"))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+async def convert_toman_to_crypto(amount_toman: int, symbol: str = "trx") -> tuple[float, float]:
+    if amount_toman <= 0:
+        raise ValueError("Amount must be greater than zero")
+
+    price = await get_live_price(symbol=symbol)
+
+    crypto_amount = round(amount_toman / price, 6)
+    return price, crypto_amount
+
+
+async def get_live_price(symbol: str = "trx") -> float:
+    price = await fetch_nobitex_price(symbol=symbol)
+    if price is None:
+        price = await fetch_bitpin_price(symbol=symbol)
+    if price is None:
+        raise RuntimeError("Unable to fetch live price data for the requested currency")
+    return price
+
+
+async def create_nowpayments_payment(
+    *,
+    api_key: str,
+    amount: float,
+    currency: str,
+    order_id: str,
+    description: str,
+) -> dict[str, Any]:
+    headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+    payload = {
+        "price_amount": amount,
+        "price_currency": currency,
+        "pay_currency": currency,
+        "order_id": order_id,
+        "order_description": description,
+    }
+    response = await _async_request("post", f"{NOWPAYMENTS_API_BASE}/payment", json=payload, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+async def get_nowpayments_payment_status(*, api_key: str, payment_id: str) -> dict[str, Any]:
+    headers = {"x-api-key": api_key}
+    response = await _async_request("get", f"{NOWPAYMENTS_API_BASE}/payment/{payment_id}", headers=headers)
+    response.raise_for_status()
+    return response.json()


### PR DESCRIPTION
## Summary
- add admin sales settings for managing subscription plans and NowPayments API key
- implement live-price crypto conversion and payment tracking for user /buy flow
- extend database schema with subscription, payment, and settings tables

## Testing
- python -m compileall bot utils

------
https://chatgpt.com/codex/tasks/task_e_68d95ec3ce84832baee62fd784d4910a