### PR TITLE
Fix NowPayments polling and notify users after successful payments

### DIFF
--- a/utils/payments.py
+++ b/utils/payments.py
@@ -10,7 +10,7 @@ BITPIN_MARKETS_URL = "https://api.bitpin.ir/v1/mkt/markets/"
 NOBITEX_STATS_URL = "https://api.nobitex.ir/market/stats"
 NOWPAYMENTS_API_ROOT = "https://api-sandbox.nowpayments.io/v1"
 NOWPAYMENTS_CREATE_INVOICE_URL = f"{NOWPAYMENTS_API_ROOT}/invoice"
-NOWPAYMENTS_INVOICE_STATUS_URL = f"{NOWPAYMENTS_API_ROOT}/invoice"
+NOWPAYMENTS_PAYMENT_STATUS_URL = f"{NOWPAYMENTS_API_ROOT}/payment"
 
 
 async def _async_request(method: str, url: str, **kwargs) -> requests.Response:
@@ -105,11 +105,11 @@ async def create_nowpayments_invoice(
     return response.json()
 
 
-async def get_nowpayments_invoice_status(*, api_key: str, invoice_id: str) -> dict[str, Any]:
+async def get_nowpayments_payment_status(*, api_key: str, payment_id: str) -> dict[str, Any]:
     headers = {"x-api-key": api_key}
     response = await _async_request(
         "get",
-        f"{NOWPAYMENTS_INVOICE_STATUS_URL}/{invoice_id}",
+        f"{NOWPAYMENTS_PAYMENT_STATUS_URL}/{payment_id}",
         headers=headers,
     )
     response.raise_for_status()


### PR DESCRIPTION
## Summary
- poll NowPayments using the payment status endpoint and ignore transient 404s while waiting for confirmation
- update the success notification to explicitly tell the user their subscription is active and show the expiry date

## Testing
- python -m compileall bot utils

------
https://chatgpt.com/codex/tasks/task_e_68d97a93164c832baf64c3318ff0288e