### PR TITLE
Adjust subscription flow to remove total limits

### DIFF
--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -33,9 +33,7 @@ class AdminFSM(StatesGroup):
     await_plan_name = State()
     await_plan_duration = State()
     await_plan_download_limit = State()
-    await_plan_download_total = State()
     await_plan_encode_limit = State()
-    await_plan_encode_total = State()
     await_plan_price = State()
     await_plan_description = State()
     await_wallet_address = State()
@@ -74,8 +72,6 @@ async def build_subscription_overview(session: AsyncSession) -> tuple[str, Inlin
                     f"مدت اشتراک: {plan.duration_days} روز\n"
                     f"سقف دانلود روزانه: {_format_limit_value(plan.download_limit_per_day)}\n"
                     f"سقف انکد روزانه: {_format_limit_value(plan.encode_limit_per_day)}\n"
-                    f"سقف دانلود کل: {_format_limit_value(plan.download_limit)}\n"
-                    f"سقف انکد کل: {_format_limit_value(plan.encode_limit)}\n"
                     f"قیمت: {plan.price_toman:,} تومان"
                 )
             )
@@ -330,21 +326,6 @@ async def sales_plan_receive_download_limit(message: types.Message, state: FSMCo
     plan = data.get("new_plan", {})
     plan["download_limit_per_day"] = limit
     await state.update_data(new_plan=plan)
-    await message.answer("سقف دانلود کلی را وارد کنید (برای نامحدود عدد -1 را ارسال کنید):")
-    await state.set_state(AdminFSM.await_plan_download_total)
-
-
-@router.message(AdminFSM.await_plan_download_total)
-async def sales_plan_receive_download_total(message: types.Message, state: FSMContext):
-    try:
-        limit = int(message.text)
-    except (TypeError, ValueError):
-        await message.answer("لطفاً یک عدد صحیح وارد کنید:")
-        return
-    data = await state.get_data()
-    plan = data.get("new_plan", {})
-    plan["download_limit"] = limit
-    await state.update_data(new_plan=plan)
     await message.answer("سقف انکد روزانه را وارد کنید (برای نامحدود عدد -1 را ارسال کنید):")
     await state.set_state(AdminFSM.await_plan_encode_limit)
 
@@ -359,21 +340,6 @@ async def sales_plan_receive_encode_limit(message: types.Message, state: FSMCont
     data = await state.get_data()
     plan = data.get("new_plan", {})
     plan["encode_limit_per_day"] = limit
-    await state.update_data(new_plan=plan)
-    await message.answer("سقف انکد کلی را وارد کنید (برای نامحدود عدد -1 را ارسال کنید):")
-    await state.set_state(AdminFSM.await_plan_encode_total)
-
-
-@router.message(AdminFSM.await_plan_encode_total)
-async def sales_plan_receive_encode_total(message: types.Message, state: FSMContext):
-    try:
-        limit = int(message.text)
-    except (TypeError, ValueError):
-        await message.answer("لطفاً یک عدد صحیح وارد کنید:")
-        return
-    data = await state.get_data()
-    plan = data.get("new_plan", {})
-    plan["encode_limit"] = limit
     await state.update_data(new_plan=plan)
     await message.answer("قیمت اشتراک را به تومان وارد کنید:")
     await state.set_state(AdminFSM.await_plan_price)


### PR DESCRIPTION
## Summary
- remove the total download/encode limit fields from the admin subscription configuration and user-facing purchase flow
- show users with an active plan a status panel with a refresh action when they invoke /buy
- reset daily usage counters at Tehran midnight and simplify plan creation storage

## Testing
- python -m compileall bot/handlers/common.py bot/handlers/admin.py utils/database.py

------
https://chatgpt.com/codex/tasks/task_e_68da9d5b99bc832bbda31f3410460ee7