### PR TITLE
Preserve formatting in help text

### DIFF
--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -544,7 +544,8 @@ async def texts_panel_callback(query: types.CallbackQuery, state: FSMContext):
 
 @router.message(AdminFSM.await_help_text)
 async def await_help_text_handler(message: types.Message, state: FSMContext, session: AsyncSession):
-    await database.set_text(session, key="help_text", value=message.text)
+    stored_text = message.html_text if message.html_text is not None else message.text
+    await database.set_text(session, key="help_text", value=stored_text)
     await message.answer("✅ Help text updated successfully.")
     await state.set_state(AdminFSM.panel)
 

--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -1,4 +1,5 @@
 from aiogram import Router, types, F
+from aiogram.enums import ParseMode
 from aiogram.filters import Command, CommandStart
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
@@ -136,7 +137,7 @@ async def handle_help(message: types.Message, session: AsyncSession):
     Handler for the /help command. Displays the help text.
     """
     help_text = await database.get_text(session, key="help_text", default="متن راهنما هنوز تنظیم نشده است.")
-    await message.answer(help_text)
+    await message.answer(help_text, parse_mode=ParseMode.HTML, disable_web_page_preview=True)
 
 
 @router.message(Command("buy"))


### PR DESCRIPTION
## Summary
- preserve the admin-provided HTML formatting when sending the help message
- store the HTML-formatted help text from Telegram instead of the plain text version

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68daa315f20c832b9f3d9f25b07aaa3e