### PR TITLE
Replace encode wording with video editing

### DIFF
--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -151,7 +151,7 @@ async def build_subscription_overview(session: AsyncSession) -> tuple[str, Inlin
                 f"\n{idx}. {plan.name}\n"
                 f"مدت اشتراک: {plan.duration_days} روز\n"
                 f"سقف دانلود روزانه: {_format_limit_value(plan.download_limit_per_day)}\n"
-                f"سقف انکد روزانه: {_format_limit_value(plan.encode_limit_per_day)}\n"
+                f"سقف ویرایش ویدئو روزانه: {_format_limit_value(plan.encode_limit_per_day)}\n"
                 f"قیمت: {plan.price_toman:,} تومان\n"
                 f"سایت‌های فعال:\n{site_lines}\n"
                 f"امکانات: {feature_summary}"
@@ -563,7 +563,7 @@ async def sales_plan_receive_download_limit(message: types.Message, state: FSMCo
     plan = data.get("new_plan", {})
     plan["download_limit_per_day"] = limit
     await state.update_data(new_plan=plan)
-    await message.answer("سقف انکد روزانه را وارد کنید (برای نامحدود عدد -1 را ارسال کنید):")
+    await message.answer("سقف ویرایش ویدئو روزانه را وارد کنید (برای نامحدود عدد -1 را ارسال کنید):")
     await state.set_state(AdminFSM.await_plan_encode_limit)
 
 

--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -150,7 +150,7 @@ async def _build_active_subscription_response(bot, user) -> tuple[str, InlineKey
         "شما یک اشتراک فعال دارید!\n\n"
         f"روزهای باقی ماند: {_format_remaining_days(user)}\n"
         f"سقف دانلود روزانه: {_format_limit(user.sub_download_limit)}\n"
-        f"سقف انکد روزانه: {_format_limit(user.sub_encode_limit)}\n\n"
+        f"سقف ویرایش ویدئو روزانه: {_format_limit(user.sub_encode_limit)}\n\n"
         f"{bot_username}"
     )
 
@@ -171,7 +171,7 @@ async def handle_start(message: types.Message, state: FSMContext, session: Async
 
     start_message = (
         "خوش آمدید!\n\n"
-        "کافیست لینک یکی از سایت‌های پشتیبانی‌شده را بفرستید تا دانلود شروع شود، یا ویدیوی خود را ارسال کنید تا وارد پنل انکد شوید."
+        "کافیست لینک یکی از سایت‌های پشتیبانی‌شده را بفرستید تا دانلود شروع شود، یا ویدیوی خود را ارسال کنید تا وارد پنل ویرایش ویدئو شوید."
     )
     await message.answer(start_message, reply_markup=get_main_reply_keyboard())
 
@@ -189,7 +189,7 @@ async def start_encode_flow(query: types.CallbackQuery, state: FSMContext):
     """Reminds the user how to begin an encode."""
     await state.set_state(UserFlow.encoding)
     await query.message.edit_text(
-        "برای ورود به پنل انکد، ویدیوی مورد نظر خود را ارسال کنید."
+        "برای ورود به پنل ویرایش ویدئو، ویدیوی مورد نظر خود را ارسال کنید."
     )
     await query.answer()
 
@@ -303,7 +303,7 @@ async def handle_buy_plan_selection(query: types.CallbackQuery, state: FSMContex
         f"اشتراک انتخابی: {plan.name}\n"
         f"مدت اشتراک: {plan.duration_days} روز\n"
         f"سقف دانلود روزانه: {_format_limit(plan.download_limit_per_day)}\n"
-        f"سقف انکد روزانه: {_format_limit(plan.encode_limit_per_day)}\n"
+        f"سقف ویرایش ویدئو روزانه: {_format_limit(plan.encode_limit_per_day)}\n"
         f"سایت‌های فعال:\n{site_lines}\n"
         f"امکانات: {feature_text}\n"
         f"توضیحات: {description}\n"

--- a/bot/handlers/video.py
+++ b/bot/handlers/video.py
@@ -287,7 +287,7 @@ async def handle_start_button(query: types.CallbackQuery, state: FSMContext, ses
 
     await database.record_task_usage(session, user_id, "encode")
 
-    await query.message.edit_text("✅ درخواست شما به صف انکد اضافه شد...")
+    await query.message.edit_text("✅ درخواست شما به صف ویرایش ویدئو اضافه شد...")
     video_tasks.encode_video_task.delay(
         user_id=user_id,
         username=query.from_user.username or "N/A",

--- a/utils/database.py
+++ b/utils/database.py
@@ -162,7 +162,7 @@ async def record_task_usage(
 def format_task_limit_message(task_type: str, limit: int, used_today: int) -> str:
     """Returns a localized message explaining the daily task limit."""
     task_label = {
-        "encode": "انکد",
+        "encode": "ویرایش ویدئو",
         "download": "دانلود",
     }.get(task_type, task_type)
 


### PR DESCRIPTION
## Summary
- update user-facing Persian strings to refer to video editing instead of encoding
- align admin and task limit labels with the new terminology

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e009ffd958832b8900c021f36c28e3